### PR TITLE
Fix/route export null node

### DIFF
--- a/synplan/chem/reaction/routes/io.py
+++ b/synplan/chem/reaction/routes/io.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from chython import smiles as read_smiles
@@ -7,6 +8,23 @@ from chython.exceptions import InvalidAromaticRing
 
 if TYPE_CHECKING:
     from synplan.mcts.tree import Tree
+
+logger = logging.getLogger(__name__)
+
+
+def _route_tree_has_null_node(node) -> bool:
+    """Return True if the assembled route tree contains a ``None`` node.
+
+    ``build_mol_node`` returns ``None`` when a route is malformed (e.g. a node
+    holding more than one molecule). Such a ``None`` ends up either as the route
+    root or nested in a ``children`` list, which would serialize to a JSON
+    ``null`` child and corrupt the route.
+    """
+    if node is None:
+        return True
+    if isinstance(node, dict):
+        return any(_route_tree_has_null_node(child) for child in node.get("children", []) or [])
+    return False
 
 
 def _route_molecule_smiles(mol) -> str:
@@ -83,7 +101,7 @@ def make_dict(routes_json):
         try:
             routes_dict[int(route_idx)] = _collect_reactions(tree)
         except Exception as e:
-            print(f"Error processing route {route_idx}: {e}")
+            logger.warning("Error processing route %s: %s", route_idx, e)
 
     return routes_dict
 
@@ -162,7 +180,7 @@ def make_json(
                     s = _route_molecule_smiles(prod)
                     prod_map.setdefault(s, []).append(sid)
         except Exception as e:
-            print(f"Error processing route {route_id}: {e}")
+            logger.warning("Error processing route %s: %s", route_id, e)
             continue
 
         def build_mol_node(sid, _steps=steps, _atom_nums=atom_nums):
@@ -207,6 +225,13 @@ def make_json(
 
         # Build route tree and store
         route_tree = build_mol_node(final_step)
+        if _route_tree_has_null_node(route_tree):
+            logger.warning(
+                "Dropping malformed route %s from export: route tree contains a "
+                "null node (multiple molecules in one node / malformed route node).",
+                route_id,
+            )
+            continue
         if keep_ids:
             all_routes[int(route_id)] = route_tree
         else:

--- a/synplan/chem/reaction/routes/io.py
+++ b/synplan/chem/reaction/routes/io.py
@@ -183,9 +183,29 @@ def make_json(
             logger.warning("Error processing route %s: %s", route_id, e)
             continue
 
-        def build_mol_node(sid, _steps=steps, _atom_nums=atom_nums):
-            """Find the product with any overlap to target atoms and recurse into its reaction."""
+        def build_mol_node(sid, want_react=None, _steps=steps, _atom_nums=atom_nums):
+            """Select the product fragment of step ``sid`` and recurse into its reaction.
+
+            ``want_react`` is the consuming reactant of the next step (set by
+            ``build_reaction_node``). Selection is structural first: pick the
+            product fragment that *is* the consuming reactant by chython
+            structural equality. This recovers routes whose per-step atom-number
+            chaining leaves the relevant fragment numbered disjoint from the
+            target. When no reactant context is available (the route root), or
+            no fragment matches structurally, fall back to atom-number overlap
+            with the target.
+            """
             rxn = _steps[sid]
+            if want_react is not None:
+                for p in rxn.products:
+                    if p == want_react:
+                        smiles = _route_molecule_smiles(p)
+                        return {
+                            "type": "mol",
+                            "smiles": smiles,
+                            "children": [build_reaction_node(sid)],
+                            "in_stock": False,
+                        }
             for p in rxn.products:
                 if _atom_nums & set(p._atoms.keys()):
                     smiles = _route_molecule_smiles(p)
@@ -195,7 +215,8 @@ def make_json(
                         "children": [build_reaction_node(sid)],
                         "in_stock": False,
                     }
-            # Shouldn't reach here if tree is consistent
+            # Neither structural identity nor atom-number overlap matched: route
+            # is genuinely unrecoverable; the drop guard in make_json handles it.
             return None
 
         def build_reaction_node(
@@ -215,7 +236,7 @@ def make_json(
                 # Look up any prior step producing this reactant
                 prior = [ps for ps in _prod_map.get(r_smi, []) if ps < sid]
                 if prior:
-                    node["children"].append(build_mol_node(max(prior)))
+                    node["children"].append(build_mol_node(max(prior), want_react=react))
                 else:
                     node["children"].append(
                         {"type": "mol", "smiles": r_smi, "in_stock": True}

--- a/synplan/chem/reaction/routes/representation/route_cgr.py
+++ b/synplan/chem/reaction/routes/representation/route_cgr.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING
 
 from chython.containers import CGRContainer, MoleculeContainer, ReactionContainer
@@ -13,6 +14,8 @@ from synplan.chem.reaction.routes.representation.state import (
 
 if TYPE_CHECKING:
     from synplan.mcts.tree import Tree
+
+logger = logging.getLogger(__name__)
 
 
 def _next_atom_number(*containers):
@@ -224,7 +227,9 @@ def validate_molecule_components(curr_mol: MoleculeContainer, route_id: int):
     """
     new_rmol = [curr_mol.substructure(c) for c in curr_mol.connected_components]
     if len(new_rmol) > 1:
-        print(f"Error tree {route_id}: We have more than one molecule in one node")
+        logger.warning(
+            "Route %s: more than one molecule in one node", route_id
+        )
         return 0
 
     return 1
@@ -676,7 +681,7 @@ def compose_route_cgr(tree_or_routes, route_id, preserve_transient_bonds=True):
         return {"cgr": accum_cgr, "reactions_dict": reactions_dict}
 
     except Exception as e:
-        print(f"Error processing route {route_id}: {e}")
+        logger.warning("Error processing route %s: %s", route_id, e)
         return None
 
 

--- a/tests/regression/test_route_io_roundtrip.py
+++ b/tests/regression/test_route_io_roundtrip.py
@@ -90,3 +90,15 @@ def test_write_then_read_routes_json_is_lossless(tmp_path: Path):
         f"{rt_ids - orig_ids}. Likely cause: make_json's broad-except clause "
         "is silently dropping routes whose serialization raises."
     )
+
+    # Stronger invariant: a second write of the round-tripped dict must be
+    # byte-identical to the first. make_json is deterministic, so any change to
+    # node selection (e.g. structural vs atom-number precursor matching) that
+    # silently rewrites a valid route's connectivity would surface here.
+    routes_dict_2 = read_routes_json(str(out_path), to_dict=True)
+    out_path_2 = tmp_path / "rt2.json"
+    write_routes_json(routes_dict_2, str(out_path_2))
+    assert out_path_2.read_bytes() == out_path.read_bytes(), (
+        "write->read->write is not byte-stable: make_json changed a valid "
+        "route's serialized form across an identity round-trip."
+    )

--- a/tests/unit/chem/reaction_routes/test_make_json_null_node.py
+++ b/tests/unit/chem/reaction_routes/test_make_json_null_node.py
@@ -1,28 +1,30 @@
-"""Route export must drop malformed routes instead of emitting a null node.
+"""Route export recovers disjoint-numbering routes; guard stays as safety net.
 
-``make_json`` builds each route via ``build_mol_node``, which returns ``None``
-for a malformed node (e.g. a node holding more than one molecule). Without the
-guard, that ``None`` is written into the tree as a JSON ``null`` child, which
-downstream consumers (retrocast) reject as schema-invalid. The fix drops the
-whole malformed route and logs a warning; valid routes are untouched.
+``make_json`` builds each precursor mol-node by selecting the producing step's
+product fragment. Selecting by atom-number overlap with the target fails on deep
+routes where per-step atom-number chaining leaves the relevant fragment numbered
+disjoint from the target, yielding a ``None`` node (JSON ``null``) that
+downstream consumers reject. The fix selects the fragment that *is* the consuming
+reactant by chython structural equality, recovering the route regardless of
+numbering. The drop guard (``_route_tree_has_null_node``) remains as a last-resort
+safety net for any genuinely unrecoverable tree.
 """
 
 from __future__ import annotations
-
-import logging
 
 from chython import smiles as read_smiles
 
 from synplan.chem.reaction.routes.io import _route_tree_has_null_node, make_json
 
 
-def _malformed_route_steps():
-    """Two-step route whose nested ``build_mol_node`` returns ``None``.
+def _disjoint_numbering_route_steps():
+    """Two-step route whose precursor fragment is numbered disjoint from target.
 
-    The final step's reactant SMILES matches an earlier step's product, so the
-    prior-step lookup recurses into ``build_mol_node``. That earlier product
-    carries atom numbers disjoint from the final target's atoms, so the overlap
-    check fails and ``build_mol_node`` hits its ``return None`` branch.
+    The final step's reactant ``CC`` matches an earlier step's product ``CC``, so
+    the prior-step lookup recurses into ``build_mol_node``. That earlier product
+    carries atom numbers (50, 51) disjoint from the final target ``O=O`` atoms
+    (1, 2). Atom-number overlap selection fails; structural selection (the
+    product fragment that *equals* the consuming reactant) recovers the route.
     """
     final_step = read_smiles("[C:1][C:2]>>[O:1]=[O:2]")
     prior_step = read_smiles("[Br:60]>>[C:50][C:51]")
@@ -34,6 +36,21 @@ def _valid_route_steps():
     return {0: read_smiles("[C:1][C:2][C:3].[N:10]>>[C:1][C:2][C:3][N:10]")}
 
 
+def _assert_well_formed(node, expect="mol"):
+    """Valid mol/reaction alternation, no null node, non-empty mol smiles."""
+    assert isinstance(node, dict), f"expected dict node, got {node!r}"
+    assert node.get("type") == expect, f"expected {expect}, got {node.get('type')!r}"
+    children = node.get("children") or []
+    if expect == "mol":
+        assert node.get("smiles"), "mol node missing smiles"
+        for child in children:
+            _assert_well_formed(child, "reaction")
+    else:
+        assert children, "reaction node must have at least one mol child"
+        for child in children:
+            _assert_well_formed(child, "mol")
+
+
 def test_route_tree_has_null_node_detects_nested_none():
     assert _route_tree_has_null_node(None) is True
     nested = {"type": "mol", "children": [{"type": "reaction", "children": [None]}]}
@@ -42,32 +59,69 @@ def test_route_tree_has_null_node_detects_nested_none():
     assert _route_tree_has_null_node(clean) is False
 
 
-def test_make_json_drops_malformed_route(caplog):
-    routes_dict = {5: _valid_route_steps(), 9: _malformed_route_steps()}
+def test_make_json_recovers_disjoint_numbering_route():
+    """The disjoint-numbering route is recovered (well-formed), not dropped."""
+    routes_dict = {5: _valid_route_steps(), 9: _disjoint_numbering_route_steps()}
 
-    with caplog.at_level(logging.WARNING, logger="synplan.chem.reaction.routes.io"):
-        out = make_json(routes_dict)
+    out = make_json(routes_dict)
 
-    # (a) malformed route absent; no null-child tree emitted.
-    assert 9 not in out
+    # Both routes present; neither contains a null node.
+    assert 5 in out and 9 in out
     assert all(not _route_tree_has_null_node(tree) for tree in out.values())
 
-    # (b) valid route unaffected.
-    assert 5 in out
+    # Recovered route is a well-formed tree with correct mol/reaction alternation.
+    _assert_well_formed(out[9], "mol")
+    # The precursor fragment selected by structure is the ``CC`` reactant, which
+    # recurses into the prior step that produces it.
+    assert out[9]["smiles"] == "O=O"
+    rxn_node = out[9]["children"][0]
+    assert rxn_node["type"] == "reaction"
+    cc_node = rxn_node["children"][0]
+    assert cc_node["type"] == "mol" and cc_node["smiles"] == "CC"
+    assert cc_node["in_stock"] is False
+    assert cc_node["children"][0]["type"] == "reaction"
+
+    # Valid route unaffected.
     assert out[5]["type"] == "mol"
     assert out[5]["smiles"] == "CCCN"
 
-    # (c) warning logged (not printed) naming the dropped route.
-    assert any(
-        record.levelno == logging.WARNING and "9" in record.getMessage()
-        for record in caplog.records
-    )
 
-
-def test_make_json_keep_ids_false_excludes_malformed_route():
-    routes_dict = {5: _valid_route_steps(), 9: _malformed_route_steps()}
+def test_make_json_keep_ids_false_recovers_disjoint_numbering_route():
+    routes_dict = {5: _valid_route_steps(), 9: _disjoint_numbering_route_steps()}
     out = make_json(routes_dict, keep_ids=False)
     assert isinstance(out, list)
-    assert len(out) == 1
-    assert out[0]["smiles"] == "CCCN"
-    assert not _route_tree_has_null_node(out[0])
+    assert len(out) == 2
+    assert all(not _route_tree_has_null_node(tree) for tree in out)
+    assert {tree["smiles"] for tree in out} == {"CCCN", "O=O"}
+
+
+def test_make_json_drops_route_when_selection_unrecoverable(monkeypatch):
+    """The drop guard stays the safety net for genuinely unrecoverable trees.
+
+    Structural and atom-number selection both succeed for any route whose
+    precursor producer is found via ``prod_map`` (same route SMILES implies
+    structural equality), so the make_json-level ``None`` path is unreachable
+    through normal routes. We force the unrecoverable case by making the nested
+    precursor selection return ``None`` for the disjoint-numbering route and
+    assert ``make_json`` drops the whole route rather than emitting a ``null``
+    child, while the valid route is untouched.
+    """
+    import synplan.chem.reaction.routes.io as io_mod
+
+    routes_dict = {5: _valid_route_steps(), 9: _disjoint_numbering_route_steps()}
+
+    # Force the structural ``want_react`` branch off: with no structural match
+    # and atom numbers disjoint from the target, build_mol_node hits ``None``
+    # only for route 9 (route 5 has a single step with no prior-producer
+    # recursion, so its root selection still resolves by atom overlap).
+    from chython.containers import MoleculeContainer
+
+    monkeypatch.setattr(MoleculeContainer, "__eq__", lambda self, other: False)
+
+    out = io_mod.make_json(routes_dict)
+
+    # Route 9 is unrecoverable under forced selection failure -> dropped, not null.
+    assert 9 not in out
+    assert all(not _route_tree_has_null_node(tree) for tree in out.values())
+    # Valid single-step route still exported.
+    assert 5 in out and out[5]["smiles"] == "CCCN"

--- a/tests/unit/chem/reaction_routes/test_make_json_null_node.py
+++ b/tests/unit/chem/reaction_routes/test_make_json_null_node.py
@@ -1,0 +1,73 @@
+"""Route export must drop malformed routes instead of emitting a null node.
+
+``make_json`` builds each route via ``build_mol_node``, which returns ``None``
+for a malformed node (e.g. a node holding more than one molecule). Without the
+guard, that ``None`` is written into the tree as a JSON ``null`` child, which
+downstream consumers (retrocast) reject as schema-invalid. The fix drops the
+whole malformed route and logs a warning; valid routes are untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from chython import smiles as read_smiles
+
+from synplan.chem.reaction.routes.io import _route_tree_has_null_node, make_json
+
+
+def _malformed_route_steps():
+    """Two-step route whose nested ``build_mol_node`` returns ``None``.
+
+    The final step's reactant SMILES matches an earlier step's product, so the
+    prior-step lookup recurses into ``build_mol_node``. That earlier product
+    carries atom numbers disjoint from the final target's atoms, so the overlap
+    check fails and ``build_mol_node`` hits its ``return None`` branch.
+    """
+    final_step = read_smiles("[C:1][C:2]>>[O:1]=[O:2]")
+    prior_step = read_smiles("[Br:60]>>[C:50][C:51]")
+    return {0: prior_step, 1: final_step}
+
+
+def _valid_route_steps():
+    """A single-step route that serializes to a well-formed tree."""
+    return {0: read_smiles("[C:1][C:2][C:3].[N:10]>>[C:1][C:2][C:3][N:10]")}
+
+
+def test_route_tree_has_null_node_detects_nested_none():
+    assert _route_tree_has_null_node(None) is True
+    nested = {"type": "mol", "children": [{"type": "reaction", "children": [None]}]}
+    assert _route_tree_has_null_node(nested) is True
+    clean = {"type": "mol", "children": [{"type": "reaction", "children": []}]}
+    assert _route_tree_has_null_node(clean) is False
+
+
+def test_make_json_drops_malformed_route(caplog):
+    routes_dict = {5: _valid_route_steps(), 9: _malformed_route_steps()}
+
+    with caplog.at_level(logging.WARNING, logger="synplan.chem.reaction.routes.io"):
+        out = make_json(routes_dict)
+
+    # (a) malformed route absent; no null-child tree emitted.
+    assert 9 not in out
+    assert all(not _route_tree_has_null_node(tree) for tree in out.values())
+
+    # (b) valid route unaffected.
+    assert 5 in out
+    assert out[5]["type"] == "mol"
+    assert out[5]["smiles"] == "CCCN"
+
+    # (c) warning logged (not printed) naming the dropped route.
+    assert any(
+        record.levelno == logging.WARNING and "9" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_make_json_keep_ids_false_excludes_malformed_route():
+    routes_dict = {5: _valid_route_steps(), 9: _malformed_route_steps()}
+    out = make_json(routes_dict, keep_ids=False)
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert out[0]["smiles"] == "CCCN"
+    assert not _route_tree_has_null_node(out[0])


### PR DESCRIPTION
fix: recover routes dropped by atom-numbering mismatch in route export

 ~0.3% of exported routes (189 of 63k on mkt-lin-500 syntharena bench, across 19 targets) came out with a null child node and were rejected downstream as malformed.

Root cause: make_json.build_mol_node selects each precursor mol-node by matching atom numbers against the target atom set. On deep routes with repeated/symmetric reagent fragments (pivaloyl/SEM/leaving groups), compose_route_cgr's per-step number chaining leaves a secondary product fragment numbered disjoint from the target, so no fragment overlaps → build_mol_node returns None → null child. The correspondence isn't truly lost: that fragment is only reached because a prior step produces its canonical SMILES.

Fix: Select the precursor fragment by molecule identity (p == want_react, numbering-independent), falling back to the existing atom-number overlap, and returning None (→ route dropped, as a final safety net) only if neither matches. Change is confined to make_json; compose_route_cgr is untouched, so RouteCGR hashes are unchanged.