### PR TITLE
Draw routes as trees, keep precursors oriented, and write one self-contained report

### DIFF
--- a/synplan/mcts/tree.py
+++ b/synplan/mcts/tree.py
@@ -767,6 +767,10 @@ class Tree:
         """Given a node_id, return a tuple of reactions that represent the
         retrosynthetic route from the current node.
 
+        Molecules keep the coordinates the reactor gave them, so a precursor still
+        sits where its atoms sat in the product. Callers that need a layout of their
+        own call ``clean2d()`` themselves.
+
         :param node_id: The id of the current node.
         :return: The tuple of extracted reactions representing the synthesis route.
         """
@@ -779,8 +783,6 @@ class Tree:
             for before, after in iter_route_steps(self, node_id)
         ]
 
-        for r in reaction_sequence:
-            r.clean2d()
         return tuple(reversed(reaction_sequence))
 
     def newickify(self, visits_threshold: int = 0, root_node_id: int = 1):

--- a/synplan/utils/align2d.py
+++ b/synplan/utils/align2d.py
@@ -1,0 +1,143 @@
+"""Rigid 2D alignment of route precursors onto the product they came from.
+
+Kabsch/Procrustes on the shared atom-map numbers, closed form for 2x2. Reflection is
+allowed: chython derives wedges from coordinates at render time, so mirroring is
+stereo-safe provided the ``_wedge_map`` cache is dropped.
+"""
+
+from __future__ import annotations
+
+from math import atan2, cos, degrees, hypot, sin
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from chython.containers.molecule import MoleculeContainer
+
+__all__ = ["align_molecule", "align_route", "apply_transform"]
+
+
+def _centroid(points):
+    n = len(points)
+    return sum(x for x, _ in points) / n, sum(y for _, y in points) / n
+
+
+def _rmsd(a, b):
+    return (
+        sum(hypot(ax - bx, ay - by) ** 2 for (ax, ay), (bx, by) in zip(a, b)) / len(a)
+    ) ** 0.5
+
+
+def _mean_dist(a, b):
+    return sum(hypot(ax - bx, ay - by) for (ax, ay), (bx, by) in zip(a, b)) / len(a)
+
+
+def _fit(src, dst, reflect: bool):
+    """Best rigid map src -> dst. Returns (matrix, src centre, dst centre, angle, rmsd)."""
+
+    cx, cy = _centroid(src)
+    dx, dy = _centroid(dst)
+    a = [(x - cx, -(y - cy) if reflect else y - cy) for x, y in src]
+    b = [(x - dx, y - dy) for x, y in dst]
+
+    angle = atan2(
+        sum(ax * by - ay * bx for (ax, ay), (bx, by) in zip(a, b)),
+        sum(ax * bx + ay * by for (ax, ay), (bx, by) in zip(a, b)),
+    )
+    c, s = cos(angle), sin(angle)
+    flip = -1 if reflect else 1
+    matrix = (c, -s * flip, s, c * flip)  # rotation with the mirror folded in
+    rmsd = _rmsd([(c * ax - s * ay, s * ax + c * ay) for ax, ay in a], b)
+    return matrix, (cx, cy), (dx, dy), angle, rmsd
+
+
+def apply_transform(
+    mol: MoleculeContainer,
+    matrix: tuple[float, float, float, float],
+    src_centre: tuple[float, float],
+    dst_centre: tuple[float, float],
+) -> None:
+    """Map every atom of `mol` through `matrix` taken about `src_centre`."""
+
+    a, b, c, d = matrix
+    cx, cy = src_centre
+    dx, dy = dst_centre
+    for _, atom in mol.atoms():
+        x, y = atom.x - cx, atom.y - cy
+        atom.xy = (a * x + b * y + dx, c * x + d * y + dy)
+    # wedges are derived from coordinates and cached; a mirror silently inverts every
+    # stereocentre unless the cache is dropped
+    mol.__dict__.pop("_wedge_map", None)
+    mol.__dict__.pop("__cached_method__repr_svg_", None)
+
+
+def align_molecule(
+    mol: MoleculeContainer, ref: MoleculeContainer, allow_reflection: bool = True
+) -> dict[str, Any]:
+    """Rotate/reflect `mol` in place so its shared atoms sit as they do in `ref`.
+
+    Shared atoms are those carrying the same atom-map number in both. `mode` is
+    ``rigid``, ``underdetermined`` (fewer than two usable shared atoms, layout left
+    alone) or ``skipped`` (nothing shared).
+    """
+
+    shared = sorted(set(mol) & set(ref))
+    stats = {
+        "n_shared": len(shared),
+        "mode": "skipped",
+        "reflected": False,
+        "angle_deg": 0.0,
+        "before": None,
+        "after": None,
+    }
+    if not shared:
+        return stats
+
+    src = [(mol.atom(n).x, mol.atom(n).y) for n in shared]
+    dst = [(ref.atom(n).x, ref.atom(n).y) for n in shared]
+
+    # translation is free (the renderer re-origins every molecule anyway), so measure
+    # the mismatch that only a rotation or a mirror can remove
+    cx, cy = _centroid(src)
+    dx, dy = _centroid(dst)
+    stats["before"] = stats["after"] = _mean_dist(
+        [(x - cx, y - cy) for x, y in src], [(x - dx, y - dy) for x, y in dst]
+    )
+
+    if len(shared) < 2 or max(hypot(x - cx, y - cy) for x, y in src) < 1e-6:
+        stats["mode"] = "underdetermined"
+        return stats
+
+    best = _fit(src, dst, False)
+    if allow_reflection:
+        mirrored = _fit(src, dst, True)
+        if mirrored[4] < best[4] - 1e-9:
+            best, stats["reflected"] = mirrored, True
+    matrix, src_centre, dst_centre, angle, _ = best
+
+    apply_transform(mol, matrix, src_centre, dst_centre)
+    stats["mode"] = "rigid"
+    stats["angle_deg"] = degrees(angle)
+    stats["after"] = _mean_dist([(mol.atom(n).x, mol.atom(n).y) for n in shared], dst)
+    return stats
+
+
+def align_route(
+    steps: Sequence[Any], allow_reflection: bool = True
+) -> list[dict[str, Any]]:
+    """Align every precursor of a `Tree.synthesis_route` onto its product.
+
+    `steps` comes back leaf-first, so walk it in reverse: the target keeps its layout
+    and each disconnection inherits from the molecule above it.
+    """
+
+    report = []
+    for reaction in reversed(steps):
+        product = reaction.products[0]
+        for precursor in reaction.reactants:
+            stats = align_molecule(precursor, product, allow_reflection)
+            stats["product"] = str(product)
+            stats["precursor"] = str(precursor)
+            report.append(stats)
+    return report

--- a/synplan/utils/routedraw.py
+++ b/synplan/utils/routedraw.py
@@ -1,0 +1,253 @@
+"""Draws one retrosynthetic route as a single SVG.
+
+Boxed chython depictions on a tidy-tree layout, pale role tints, hairline connectors
+and a numbered disc per disconnection, counting back from the target. A page showing
+these must also carry :data:`ROUTE_CSS` and one copy of :data:`ARROW_DEFS`.
+"""
+
+from __future__ import annotations
+
+import re
+from math import cos, radians, sin
+from typing import TYPE_CHECKING, Any
+
+from synplan.utils.align2d import align_route
+from synplan.utils.routelayout import Node, edges, layout, walk
+
+if TYPE_CHECKING:
+    from chython.containers.molecule import MoleculeContainer
+
+__all__ = [
+    "ARROW_DEFS",
+    "ROLE_STYLE",
+    "ROUTE_CSS",
+    "draw_route",
+    "molecule_svg",
+    "orient_route",
+]
+
+#: Depiction units to px, and the white margin between a depiction and its frame.
+PX_PER_UNIT = 26.0
+BOX_PAD = 9.0
+ROW_GAP = 34.0  # 18 for air plus 16 for the caption band above a box
+
+#: fill, stroke, stroke width per role.
+ROLE_STYLE = {
+    "target": ("#f3f6fb", "#94a6cb", 1.6),
+    "bb": ("#f3f8f5", "#9dbcae", 1.0),
+    "int": ("#ffffff", "#edeff1", 1.0),
+    "oos": ("#ffffff", "#c9cfd5", 1.0),
+}
+ROLE_CAPTION = {
+    "target": ("TARGET", "#41598f"),
+    "bb": ("IN STOCK", "#4a7a66"),
+    "oos": ("NOT IN STOCK", "#6b7480"),
+}
+
+_FONT = "Inter Tight,system-ui,sans-serif"
+ROUTE_CSS = (
+    ".sp-link{fill:none;stroke:#c4cbd3;stroke-width:1.5;stroke-linecap:round;"
+    "stroke-linejoin:round}"
+    ".sp-lead{fill:none;stroke:#c4cbd3;stroke-width:1.5;stroke-linecap:round}"
+    f".sp-tag{{font-family:{_FONT};font-size:8.5px;font-weight:700;letter-spacing:.5px}}"
+    ".sp-num{text-anchor:middle;dominant-baseline:central;font-weight:700;fill:#fff;"
+    f"font-family:{_FONT};font-size:11px}}"
+)
+ARROW_DEFS = (
+    '<marker id="sp-arrow" markerWidth="7" markerHeight="7" refX="5.4" refY="2.6" '
+    'orient="auto"><path d="M0.6,0.7 L5.2,2.6 L0.6,4.5" fill="none" stroke="#c4cbd3" '
+    'stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/></marker>'
+)
+
+_VIEWBOX = re.compile(r'viewBox="(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+)"')
+
+
+def _is_degenerate(mol: MoleculeContainer) -> bool:
+    """chython's own test for "never laid out": every atom on one point."""
+    if len(mol) < 2:
+        return False
+    xs = [atom.x for _, atom in mol.atoms()]
+    ys = [atom.y for _, atom in mol.atoms()]
+    return max(xs) - min(xs) < 0.01 and max(ys) - min(ys) < 0.01
+
+
+def _depiction(mol: MoleculeContainer) -> tuple[str, list[float]]:
+    if _is_degenerate(mol):
+        mol.clean2d()
+    svg = mol.depict()
+    match = _VIEWBOX.search(svg)
+    if match is None:
+        raise ValueError(f"chython depiction of {mol} carries no viewBox")
+    return svg, [float(v) for v in match.groups()]
+
+
+def molecule_svg(mol: MoleculeContainer, px: float = 22.0, cap: float = 300.0) -> str:
+    """A standalone depiction of ``mol`` at ``px`` per bond, capped at ``cap`` wide."""
+    svg, box = _depiction(mol)
+    inner = svg[svg.index(">", svg.index("<svg")) + 1 : svg.rindex("</svg>")]
+    scale = min(px, cap / box[2]) if box[2] else px
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{box[2] * scale:.0f}" '
+        f'height="{box[3] * scale:.0f}" viewBox="{box[0]} {box[1]} {box[2]} {box[3]}">'
+        f"{inner}</svg>"
+    )
+
+
+def orient_route(steps: Any, step_deg: int = 5) -> int:
+    """Rotate every molecule of the route by one shared angle, in place.
+
+    Alignment fixes each precursor relative to its product; the absolute angle of the
+    whole route is still free, so spend it on the shape this layout stacks best —
+    smallest summed height, then smallest column width.
+    """
+    mols, seen = [], set()
+    for reaction in steps:
+        for mol in (*reaction.reactants, *reaction.products):
+            if id(mol) not in seen:
+                seen.add(id(mol))
+                mols.append(mol)
+
+    coords = [[(atom.x, atom.y) for _, atom in mol.atoms()] for mol in mols]
+    best = None
+    for deg in range(0, 180, step_deg):
+        angle = radians(deg)
+        c, s = cos(angle), sin(angle)
+        height = width = 0.0
+        for points in coords:
+            xs = [x * c - y * s for x, y in points]
+            ys = [x * s + y * c for x, y in points]
+            height += max(ys) - min(ys)
+            width = max(width, max(xs) - min(xs))
+        if best is None or (height, width) < best[0]:
+            best = ((height, width), deg)
+
+    deg = best[1]
+    if deg:
+        angle = radians(deg)
+        c, s = cos(angle), sin(angle)
+        for mol, points in zip(mols, coords):
+            for (_, atom), (x, y) in zip(mol.atoms(), points):
+                atom.xy = (x * c - y * s, x * s + y * c)
+            # wedges are derived from the coordinates and cached
+            mol.__dict__.pop("_wedge_map", None)
+            mol.__dict__.pop("__cached_method__repr_svg_", None)
+    return deg
+
+
+def _route_tree(tree: Any, node_id: int, align: bool) -> tuple[Node, dict, tuple]:
+    steps = tree.synthesis_route(node_id)
+    if align:
+        align_route(steps)
+        orient_route(steps)
+
+    by_product = {str(r.products[0]): r for r in steps}
+    building_blocks = tree.building_blocks
+    depicts = {}
+
+    def build(mol: MoleculeContainer) -> Node:
+        key = str(mol)
+        svg, box = _depiction(mol)
+        depicts[id(mol)] = (svg, box)
+        node = Node(
+            key=key,
+            w=box[2] * PX_PER_UNIT + 2 * BOX_PAD,
+            h=box[3] * PX_PER_UNIT + 2 * BOX_PAD,
+        )
+        node.mol = mol
+        reaction = by_product.get(key)
+        if reaction is None:
+            node.role = "bb" if key in building_blocks else "oos"
+        else:
+            node.role = "int"
+            node.children = [build(m) for m in reaction.reactants]
+        return node
+
+    root = build(steps[-1].products[0])
+    root.role = "target"
+    return root, depicts, steps
+
+
+def _to_svg(root: Node, depicts: dict, ranked: list[dict], w: float, h: float) -> str:
+    top = 16.0  # room for the role caption drawn above a box
+    margin = 14.0  # frame strokes are centred on the box edge; keep them on the canvas
+    width, height = w + 2 * margin, h + top + 2 * margin
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'xmlns:xlink="http://www.w3.org/1999/xlink" width="{width:.0f}" '
+        f'height="{height:.0f}" viewBox="0 0 {width:.0f} {height:.0f}">',
+        f'<g transform="translate({margin:.0f},{top + margin:.0f})">',
+    ]
+
+    for edge in ranked:
+        lane, (px, py) = edge["lane"], edge["parent"]
+        for cx, cy in edge["children"]:
+            dy = py - cy
+            if abs(dy) < 0.5:
+                path = f"M{cx:.1f} {cy:.1f} H{lane:.1f}"
+            else:
+                sign = 1 if dy > 0 else -1
+                r = min(16.0, abs(dy) / 2, abs(lane - cx) / 2)
+                path = (
+                    f"M{cx:.1f} {cy:.1f} H{lane - r:.1f} Q{lane:.1f} {cy:.1f} "
+                    f"{lane:.1f} {cy + sign * r:.1f} V{py:.1f}"
+                )
+            parts.append(f'<path d="{path}" class="sp-link"/>')
+        parts.append(
+            f'<path d="M{lane:.1f} {py:.1f} H{px:.1f}" class="sp-lead" '
+            f'marker-end="url(#sp-arrow)"/>'
+        )
+
+    for node in [root, *walk(root)]:
+        fill, stroke, stroke_width = ROLE_STYLE[node.role]
+        parts.append(
+            f'<rect x="{node.x:.1f}" y="{node.y:.1f}" width="{node.w:.1f}" '
+            f'height="{node.h:.1f}" rx="5" fill="{fill}" stroke="{stroke}" '
+            f'stroke-width="{stroke_width}"/>'
+        )
+        svg, box = depicts[id(node.mol)]
+        inner = svg[svg.index(">", svg.index("<svg")) + 1 : svg.rindex("</svg>")]
+        parts.append(
+            f'<svg x="{node.x + BOX_PAD:.1f}" y="{node.y + BOX_PAD:.1f}" '
+            f'width="{max(1.0, node.w - 2 * BOX_PAD):.1f}" '
+            f'height="{max(1.0, node.h - 2 * BOX_PAD):.1f}" '
+            f'viewBox="{box[0]} {box[1]} {box[2]} {box[3]}">{inner}</svg>'
+        )
+        if node.role in ROLE_CAPTION:
+            caption, colour = ROLE_CAPTION[node.role]
+            parts.append(
+                f'<text x="{node.x + 1:.1f}" y="{node.y - 5:.1f}" class="sp-tag" '
+                f'fill="{colour}">{caption}</text>'
+            )
+
+    for number, edge in enumerate(ranked, 1):
+        lane, (_, py) = edge["lane"], edge["parent"]
+        parts.append(
+            f'<circle cx="{lane:.1f}" cy="{py:.1f}" r="10.5" fill="#2b3440" '
+            f'stroke="#ffffff" stroke-width="2"/>'
+            f'<text x="{lane:.1f}" y="{py:.1f}" class="sp-num">{number}</text>'
+        )
+
+    parts.append("</g></svg>")
+    return "".join(parts)
+
+
+def draw_route(
+    tree: Any, node_id: int, align: bool = True
+) -> tuple[str, list[int], tuple]:
+    """Draw the route ending at ``node_id``.
+
+    :param tree: The built tree.
+    :param node_id: The id of the node the route ends at.
+    :param align: If True, give every precursor its product's orientation.
+    :return: ``(svg, order, steps)``. ``steps`` is ``tree.synthesis_route(node_id)``
+        and ``order[i]`` indexes it for the disc numbered ``i + 1``, 1 being the cut
+        from the target.
+    """
+    root, depicts, steps = _route_tree(tree, node_id, align)
+    width, height, col_x, col_w = layout(root, row_gap=ROW_GAP)
+    ranked = sorted(
+        edges(root, col_x, col_w), key=lambda e: (e["node"].depth, e["parent"][1])
+    )
+    by_product = {str(r.products[0]): i for i, r in enumerate(steps)}
+    order = [by_product[e["node"].key] for e in ranked]
+    return _to_svg(root, depicts, ranked, width, height), order, steps

--- a/synplan/utils/routelayout.py
+++ b/synplan/utils/routelayout.py
@@ -1,0 +1,137 @@
+"""Tidy-tree layout for a retrosynthetic route. Stdlib only.
+
+A route is a tree — every molecule is made by exactly one reaction — so layer
+assignment is depth and Reingold-Tilford gives a crossing-free order. Columns are
+right-aligned, which keeps every connector inside the gap between two columns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["Node", "edges", "layout", "walk"]
+
+
+@dataclass
+class Node:
+    """One box. ``x``/``y`` are the top-left corner, filled in by :func:`layout`."""
+
+    key: str
+    w: float
+    h: float
+    children: list[Node] = field(default_factory=list)
+    x: float = 0.0
+    y: float = 0.0
+    depth: int = 0
+
+
+def layout(
+    root: Node, col_gap: float = 74.0, row_gap: float = 18.0
+) -> tuple[float, float, dict[int, float], dict[int, float]]:
+    """Position every node. The target sits on the right, the leaves on the left.
+
+    :param root: The target's node; its ``children`` are the precursors it came from.
+    :param col_gap: Empty width between two columns; the connectors live in it.
+    :param row_gap: Empty height between two stacked subtrees.
+    :return: ``(width, height, x per column, width per column)``.
+    """
+    if not col_gap > 0.0 or not row_gap >= 0.0:
+        raise ValueError(
+            f"col_gap must be > 0 and row_gap >= 0, got {col_gap}, {row_gap}"
+        )
+
+    # This walk is the only place that sees every node once, so the input is checked
+    # here: a repeat means a cycle or a shared node, a bad size means a box that
+    # would land outside its own column.
+    order, col_w, seen = [], {}, set()
+    stack = [(root, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if id(node) in seen:
+            raise ValueError(
+                f"{node.key!r} is reachable twice — input is not a tree "
+                "(cycle, self-ancestor, or one Node object used in two places)"
+            )
+        seen.add(id(node))
+        if not (0.0 <= node.w < 1e9 and 0.0 <= node.h < 1e9):  # False for NaN and inf
+            raise ValueError(
+                f"{node.key!r} has size {node.w}x{node.h}: need finite, non-negative"
+            )
+        node.depth = depth
+        order.append(node)
+        col_w[depth] = max(col_w.get(depth, 0.0), node.w)
+        stack.extend((child, depth + 1) for child in node.children)
+
+    col_x, x = {}, 0.0
+    for depth in range(max(col_w), -1, -1):  # deepest column left, target flush right
+        col_x[depth] = x
+        x += col_w[depth] + col_gap
+    total_w = x - col_gap
+
+    total_h = _place(root, 0.0, row_gap)
+    for node in order:
+        node.x = col_x[node.depth] + (col_w[node.depth] - node.w)
+    return total_w, total_h, col_x, col_w
+
+
+def _place(node: Node, top: float, row_gap: float) -> float:
+    """Stack the subtree below ``top`` and centre each parent on its children."""
+    if not node.children:
+        node.y = top
+        return top + node.h
+
+    cursor = top
+    for child in node.children:
+        cursor = _place(child, cursor, row_gap) + row_gap
+    cursor -= row_gap
+
+    first, last = node.children[0], node.children[-1]
+    node.y = (first.y + first.h / 2 + last.y + last.h / 2) / 2 - node.h / 2
+    if node.y < top:  # a parent taller than its children must not enter the row above
+        shift = top - node.y
+        for child in walk(node):
+            child.y += shift
+        node.y = top
+        cursor += shift
+    return max(cursor, node.y + node.h)
+
+
+def walk(node: Node) -> list[Node]:
+    """Every descendant of ``node``, excluding ``node`` itself."""
+    out, stack = [], list(node.children)
+    while stack:
+        child = stack.pop()
+        out.append(child)
+        stack.extend(child.children)
+    return out
+
+
+def edges(
+    root: Node,
+    col_x: dict[int, float],
+    col_w: dict[int, float],
+    lane_frac: float = 0.42,
+) -> list[dict[str, Any]]:
+    """One entry per parent: the lane x plus the child and parent anchor points.
+
+    ``lane_frac`` must stay strictly inside (0, 1): at either end the lane collapses
+    onto a column edge and the no-connector-over-a-box guarantee is gone.
+    """
+    if not 0.0 < lane_frac < 1.0:
+        raise ValueError(f"lane_frac must be strictly between 0 and 1, got {lane_frac}")
+
+    out = []
+    for node in [root, *walk(root)]:
+        if not node.children:
+            continue
+        right = col_x[node.depth + 1] + col_w[node.depth + 1]
+        out.append(
+            {
+                "node": node,
+                "lane": right + (node.x - right) * lane_frac,
+                "parent": (node.x, node.y + node.h / 2),
+                "children": [(c.x + c.w, c.y + c.h / 2) for c in node.children],
+            }
+        )
+    return out

--- a/synplan/utils/svgslim.py
+++ b/synplan/utils/svgslim.py
@@ -1,0 +1,112 @@
+"""Shrinks a page full of chython depictions.
+
+Whitespace and numeric literals are tightened losslessly, and identical molecules are
+defined once in a shared pool that every occurrence reaches through ``<use>``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+__all__ = ["Doc", "content_key", "depictions", "hidden_defs", "tighten"]
+
+_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_WS = re.compile(r">\s+<")
+_ATTR = re.compile(r'="([^"]*)"')
+_NUM = re.compile(r"-?\d+\.\d+")
+_B36 = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _b36(n: int) -> str:
+    out = ""
+    while True:
+        n, r = divmod(n, 36)
+        out = _B36[r] + out
+        if not n:
+            return out
+
+
+def _shortest(literal: str) -> str:
+    """Shortest literal parsing to the same double. Not rounding — the same number."""
+    short = repr(float(literal))
+    if short.endswith(".0"):
+        short = short[:-2]
+    if short.startswith("0."):
+        short = short[1:]
+    elif short.startswith("-0."):
+        short = "-" + short[2:]
+    if len(short) < len(literal) and float(short) == float(literal):
+        return short
+    return literal
+
+
+def tighten(svg: str) -> str:
+    """Drop chython's pretty-print and its padding zeros. No rendering effect."""
+    svg = _WS.sub("><", svg).strip()
+    return _ATTR.sub(
+        lambda m: '="' + _NUM.sub(lambda n: _shortest(n.group(0)), m.group(1)) + '"',
+        svg,
+    )
+
+
+def depictions(svg: str) -> list[tuple[int, int, str, str]]:
+    """``(start, end, opening tag, body)`` per nested depiction, in document order.
+
+    A chython depiction holds no nested ``<svg>``, so the first ``</svg>`` after the
+    wrapper closes it.
+    """
+    out, i = [], 0
+    while True:
+        i = svg.find('<svg x="', i)
+        if i < 0:
+            return out
+        head = svg.index(">", i) + 1
+        end = svg.index("</svg>", head)
+        out.append((i, end + 6, svg[i:head], svg[head:end]))
+        i = end + 6
+
+
+def content_key(body: str) -> str:
+    """Content hash of a depiction with its per-render UUID normalised away."""
+    return hashlib.sha1(_UUID.sub("U", tighten(body)).encode()).hexdigest()
+
+
+class Doc:
+    """Many routes, one pool of molecule definitions."""
+
+    def __init__(self) -> None:
+        self._ids: dict[str, str] = {}
+        self._defs: list[str] = []
+        self.hits = 0
+
+    def route(self, svg: str) -> str:
+        """Replace every depiction in ``svg`` with a ``<use>`` of the pooled copy."""
+        out, last = [], 0
+        for start, end, head, body in depictions(svg):
+            key = content_key(body)
+            self.hits += 1
+            pool_id = self._ids.get(key)
+            if pool_id is None:
+                pool_id = self._ids[key] = _b36(len(self._ids))
+                self._defs.append(_UUID.sub(pool_id, tighten(body)))
+            out.append(svg[last:start])
+            out.append(f'{head}<use xlink:href="#{pool_id}-molecule"/></svg>')
+            last = end
+        out.append(svg[last:])
+        return tighten("".join(out))
+
+    def defs(self) -> str:
+        return "".join(self._defs)
+
+    def __len__(self) -> int:
+        return len(self._ids)
+
+
+def hidden_defs(*chunks: str) -> str:
+    """An off-canvas ``<svg>`` holding the document's shared definitions."""
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" '
+        'xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0" '
+        f'style="position:absolute"><defs>{tighten("".join(chunks))}</defs></svg>'
+    )

--- a/synplan/utils/visualisation.py
+++ b/synplan/utils/visualisation.py
@@ -6,7 +6,8 @@ import base64
 import contextlib
 from collections import deque
 from datetime import datetime
-from itertools import count, islice, zip_longest
+from html import escape
+from itertools import count, islice, pairwise
 from typing import TYPE_CHECKING, Any
 
 from chython import depict_settings
@@ -15,13 +16,23 @@ from chython.algorithms.depict import _graph_svg, _render_config
 from chython.containers.molecule import MoleculeContainer
 from IPython.display import HTML, display
 
+from synplan.chem.reaction.reactor import Reaction
 from synplan.chem.reaction.routes.io import make_dict
 from synplan.chem.reaction.routes.representation.depiction import (
     cgr_display,
     depict_custom_reaction,
 )
 from synplan.chem.reaction.routes.traversal import iter_route_steps
+from synplan.utils.align2d import align_route
 from synplan.utils.frames import depict_value
+from synplan.utils.routedraw import (
+    ARROW_DEFS,
+    ROLE_STYLE,
+    ROUTE_CSS,
+    draw_route,
+    molecule_svg,
+)
+from synplan.utils.svgslim import Doc, hidden_defs
 
 if TYPE_CHECKING:
     from synplan.mcts.tree import Tree
@@ -172,12 +183,20 @@ def render_svg(pred, columns, box_colors, labeled: bool = False):
         for n, (x, y) in plane.items():
             mol._atoms[n].xy = (x, y)
 
+    def _is_degenerate(plane):
+        """chython's own test for "never laid out": everything on one point."""
+        xs = [x for x, _ in plane.values()]
+        ys = [y for _, y in plane.values()]
+        return max(xs) - min(xs) < 0.01 and max(ys) - min(ys) < 0.01
+
     for ms in columns:
         heights = []
         for m in ms:
             flat_molecules.append(m)
-            m.clean2d()
             plane = _get_plane(m)
+            if len(m) > 1 and _is_degenerate(plane):
+                m.clean2d()
+                plane = _get_plane(m)
             # X-shift for target
             min_x = min(x for x, y in plane.values()) - x_shift
             min_y = min(y for x, y in plane.values())
@@ -496,6 +515,14 @@ def _prepare_tree_route_svg_inputs(
         if layer_precursors:
             columns.append([x.molecule for x in layer_precursors])
 
+    steps = [
+        Reaction(
+            [x.molecule for x in after.new_precursors],
+            [before.curr_precursor.molecule],
+        )
+        for before, after in pairwise(nodes)
+    ]
+    align_route(steps[::-1])  # align_route takes Tree.synthesis_route order, leaf first
     return columns, tuple(pred)
 
 
@@ -644,121 +671,156 @@ def route_rule_labels(tree: Tree, node_id: int) -> list[str]:
     return list(reversed(labels))  # synthesis_route reverses; keep the pairing
 
 
+#: Page chrome for :func:`generate_results_html`. The route drawings bring their own
+#: rules through :data:`synplan.utils.routedraw.ROUTE_CSS`.
+_REPORT_CSS = """
+:root{--ink:#0f1419;--ink2:#38414a;--ink3:#6b7480;--ink4:#9ba3ad;
+--rule:#e6e8eb;--surface:#ffffff;--bg:#fafbfc;--accent:#1e3a8a;--ok:#1f4d3d}
+*,::before,::after{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-size:14px;line-height:1.5;
+font-family:"Inter Tight",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+font-variant-numeric:tabular-nums;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1180px;margin:0 auto;padding:44px 28px 96px}
+.eyebrow{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--ink3)}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}
+.card{background:var(--surface);border:1px solid var(--rule);border-radius:3px}
+header.page{padding:26px 26px 24px}
+header.page h1{margin:.35em 0 0;font-size:21px;font-weight:600;letter-spacing:-.01em}
+.target{display:flex;gap:20px;align-items:center;margin-top:20px}
+.tile{flex:0 0 auto;border:1px solid var(--accent);border-radius:3px;background:#fff;padding:9px 11px}
+.tile svg{display:block}
+.target .smi{font-size:13px;color:var(--ink2);word-break:break-all;margin-top:5px}
+.stats{display:grid;grid-template-columns:repeat(4,1fr);margin-top:24px;
+border:1px solid var(--rule);border-radius:3px;overflow:hidden;background:var(--surface)}
+.stat{padding:13px 16px 14px;border-left:1px solid var(--rule)}
+.stat:first-child{border-left:0}
+.stat .v{display:block;margin-top:5px;font-size:27px;font-weight:600;line-height:1.05;letter-spacing:-.02em}
+.stat .u{font-size:12px;font-weight:400;color:var(--ink4);letter-spacing:0}
+.legend{display:flex;flex-wrap:wrap;gap:8px;margin-top:18px}
+.chip{display:inline-flex;align-items:center;gap:7px;padding:4px 10px;background:var(--surface);
+border:1px solid var(--rule);border-radius:3px;font-size:11px;font-weight:600;
+text-transform:uppercase;letter-spacing:.1em;color:var(--ink2)}
+.sw{width:12px;height:12px;border-radius:2px;flex:0 0 auto}
+.route{margin-top:20px}
+.rhead{display:flex;flex-wrap:wrap;gap:34px;padding:13px 18px;border-bottom:1px solid var(--rule)}
+.kv .v{font-size:15px;font-weight:600;margin-top:2px}
+.kv .v.id{color:var(--accent)}
+.draw{padding:20px 18px 22px;overflow-x:auto;display:flex;justify-content:center;
+background:radial-gradient(circle,#e9ecef .9px,transparent .9px) 0 0/30px 30px,#fff}
+.draw > svg{display:block;max-width:100%;height:auto;flex:0 0 auto}
+.step{display:grid;grid-template-columns:22px minmax(0,1fr);gap:0 13px;
+align-items:start;padding:11px 18px;border-top:1px solid var(--rule)}
+.disc{width:22px;height:22px;border-radius:50%;background:#2b3440;color:#fff;
+font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;
+line-height:1;margin-top:1px}
+.lab{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--ok)}
+.rxn{font-size:12px;color:var(--ink2);word-break:break-all;line-height:1.6}
+"""
+
+#: Every role the drawing tints, in reading order.
+_ROLE_LEGEND = (
+    ("target", "Target molecule"),
+    ("int", "Intermediate"),
+    ("oos", "Not in stock"),
+    ("bb", "In stock"),
+)
+
+
+def _report_header(tree: Tree, n_routes: int) -> str:
+    target = tree.nodes[1].curr_precursor
+    tile = read_smiles(str(target))
+    tile.clean2d()
+    stats = (
+        ("Tree size", len(tree), " nodes"),
+        ("Visited nodes", len(tree.visited_nodes), ""),
+        ("Found paths", n_routes, ""),
+        ("Time", round(tree.curr_time, 4), " seconds"),
+    )
+    return (
+        '<header class="page card">'
+        '<div class="eyebrow">Retrosynthetic routes report</div>'
+        "<h1>Predicted paths</h1>"
+        f'<div class="target"><div class="tile">{molecule_svg(tile)}</div>'
+        '<div><div class="eyebrow">Target molecule</div>'
+        f'<div class="smi mono">{escape(str(target))}</div></div></div>'
+        '<div class="stats">'
+        + "".join(
+            f'<div class="stat"><span class="eyebrow">{name}</span>'
+            f'<span class="v">{value}<span class="u">{unit}</span></span></div>'
+            for name, value, unit in stats
+        )
+        + '</div><div class="legend">'
+        + "".join(
+            f'<span class="chip"><span class="sw" style="background:{ROLE_STYLE[role][0]};'
+            f'border:1px solid {ROLE_STYLE[role][1]}"></span>{caption}</span>'
+            for role, caption in _ROLE_LEGEND
+        )
+        + "</div></header>"
+    )
+
+
 def generate_results_html(
-    tree: Tree, html_path: str, aam: bool = False, extended: bool = False
-) -> None:
-    """Writes an HTML page with the synthesis routes in SVG format and corresponding
-    reactions in SMILES format.
+    tree: Tree, html_path: str | None, aam: bool = False, extended: bool = False
+) -> str | None:
+    """Writes an HTML page with the synthesis routes drawn and listed as SMILES.
+
+    Each route gets one drawing and one step list; a step's number is the number on
+    its disc in the drawing, 1 being the cut from the target. The page is
+    self-contained: no scripts, no external stylesheets, no fonts to fetch.
 
     :param tree: The built tree.
-    :param extended: If True, generates the extended route representation.
-    :param html_path: The path to the file where to store resulting HTML.
+    :param html_path: The path to the file where to store resulting HTML. When None,
+        the page is returned instead of written.
     :param aam: If True, depict atom-to-atom mapping.
-    :return: None.
+    :param extended: If True, generates the extended route representation.
+    :return: The page when ``html_path`` is None, otherwise None.
     """
-    if aam:
-        depict_settings(aam=True)
-    else:
-        depict_settings(aam=False)
+    depict_settings(aam=bool(aam))
 
-    routes = []
     if extended:
-        # Gather paths
-        for idx, node in tree.nodes.items():
-            if node.is_solved():
-                routes.append(idx)
+        routes = [idx for idx, node in tree.nodes.items() if node.is_solved()]
     else:
-        routes = tree.winning_nodes
-    # HTML Tags
-    td = '<td style="text-align: left; border: 1px solid black; border-spacing: 0">'
-    font_head = "<font style='font-weight: bold; font-size: 18px'>"
-    font_normal = "<font style='font-weight: normal; font-size: 18px'>"
-    font_close = "</font>"
+        routes = list(tree.winning_nodes)
 
-    template_begin = """
-    <!doctype html>
-    <html lang="en">
-    <head>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-    rel="stylesheet"
-    integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-    crossorigin="anonymous">
-    <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
-    crossorigin="anonymous">
-    </script>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Predicted Paths Report</title>
-    <meta name="description" content="A simple HTML5 Template for new projects.">
-    <meta name="author" content="SitePoint">
-    </head>
-    <body>
-    """
-    template_end = """
-    </body>
-    </html>
-    """
-    # SVG Template
-    box_mark = """
-    <svg width="30" height="30" viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="0.5" cy="0.5" r="0.5" fill="rgb()" fill-opacity="0.35" />
-    </svg>
-    """
-    # table = f"<table><thead><{th}>Retrosynthetic Routes</th></thead><tbody>"
-    table = """
-    <table class="table table-striped table-hover caption-top">
-    <caption><h3>Retrosynthetic Routes Report</h3></caption>
-    <tbody>"""
-
-    # Gather path data
-    table += f"<tr>{td}{font_normal}Target Molecule: {tree.nodes[1].curr_precursor!s}{font_close}</td></tr>"
-    table += f"<tr>{td}{font_normal}Tree Size: {len(tree)}{font_close} nodes</td></tr>"
-    table += f"<tr>{td}{font_normal}Number of visited nodes: {len(tree.visited_nodes)}{font_close}</td></tr>"
-    table += f"<tr>{td}{font_normal}Found paths: {len(routes)}{font_close}</td></tr>"
-    table += f"<tr>{td}{font_normal}Time: {round(tree.curr_time, 4)}{font_close} seconds</td></tr>"
-    table += f"""
-    <tr>{td}
-                 <div>
-    {box_mark.replace("rgb()", "rgb(152, 238, 255)")}
-    Target Molecule
-    {box_mark.replace("rgb()", "rgb(240, 171, 144)")}
-    Molecule Not In Stock
-    {box_mark.replace("rgb()", "rgb(155, 250, 179)")}
-    Molecule In Stock
-    </div>
-    </td></tr>
-    """
-
+    doc = Doc()
+    body = []
     for route in routes:
-        svg = get_route_svg(tree, route)  # get SVG
-        full_route = tree.synthesis_route(route)  # get route
+        svg, order, steps = draw_route(tree, route)
         labels = route_rule_labels(tree, route)
-        # write SMILES of all reactions in synthesis path
-        step = 1
-        reactions = ""
-        for synth_step, label in zip_longest(full_route, labels):
-            named = f" <i>[{label}]</i>" if label else ""
-            reactions += f"<b>Step {step}:</b>{named} {synth_step!s}<br>"
-            step += 1
-        # Concatenate all content of path
-        route_score = round(tree.route_score(route), 3)
-        table += (
-            f'<tr style="line-height: 250%">{td}{font_head}Route {route}; '
-            f"Steps: {len(full_route)}; "
-            f"Cumulated nodes' value: {route_score}{font_close}</td></tr>"
+        rows = "".join(
+            f'<div class="step"><div class="disc">{number}</div><div>'
+            + (f'<div class="lab">{escape(labels[step])}</div>' if labels[step] else "")
+            + f'<div class="rxn mono">{escape(str(steps[step]))}</div></div></div>'
+            for number, step in enumerate(order, 1)
         )
-        # f"Cumulated nodes' value: {node._probabilities[path]}{font_close}</td></tr>"
-        table += f"<tr>{td}{svg}</td></tr>"
-        table += f"<tr>{td}{reactions}</td></tr>"
-    table += "</tbody>"
+        body.append(
+            '<section class="route card"><div class="rhead">'
+            f'<div class="kv"><div class="eyebrow">Route</div>'
+            f'<div class="v id">{route}</div></div>'
+            f'<div class="kv"><div class="eyebrow">Steps</div>'
+            f'<div class="v">{len(steps)}</div></div>'
+            f'<div class="kv"><div class="eyebrow">Cumulated nodes&#39; value</div>'
+            f'<div class="v">{round(tree.route_score(route), 3)}</div></div></div>'
+            f'<div class="draw">{doc.route(svg)}</div>{rows}</section>'
+        )
+
+    page = (
+        '<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>Predicted Paths Report</title>\n"
+        f"<style>{ROUTE_CSS}{_REPORT_CSS}</style>\n</head>\n<body>\n"
+        + hidden_defs(ARROW_DEFS, doc.defs())
+        + '<div class="wrap">'
+        + _report_header(tree, len(routes))
+        + "".join(body)
+        + "</div>\n</body>\n</html>\n"
+    )
+
     if html_path is None:
-        return table
+        return page
     with open(html_path, "w", encoding="utf-8") as html_file:
-        html_file.write(template_begin)
-        html_file.write(table)
-        html_file.write(template_end)
+        html_file.write(page)
+    return None
 
 
 def html_top_routes_cluster(

--- a/tests/unit/test_align2d.py
+++ b/tests/unit/test_align2d.py
@@ -1,0 +1,96 @@
+from math import cos, hypot, sin
+
+from chython import smiles as read_smiles
+
+from synplan.chem.reaction.reactor import Reaction
+from synplan.utils.align2d import align_molecule, align_route, apply_transform
+
+
+def _scramble(mol, angle, reflect, shift):
+    """Move `mol` somewhere else on the plane, the way clean2d would."""
+    c, s = cos(angle), sin(angle)
+    flip = -1 if reflect else 1
+    apply_transform(mol, (c, -s * flip, s, c * flip), (0.0, 0.0), shift)
+
+
+def _mean_dist(mol, ref):
+    shared = sorted(set(mol) & set(ref))
+    a = [(mol.atom(n).x, mol.atom(n).y) for n in shared]
+    b = [(ref.atom(n).x, ref.atom(n).y) for n in shared]
+    ca = (sum(x for x, _ in a) / len(a), sum(y for _, y in a) / len(a))
+    cb = (sum(x for x, _ in b) / len(b), sum(y for _, y in b) / len(b))
+    return sum(
+        hypot(x - ca[0] - u + cb[0], y - ca[1] - v + cb[1])
+        for (x, y), (u, v) in zip(a, b)
+    ) / len(a)
+
+
+def _route():
+    """A two-step route whose precursors carry the target's coordinates.
+
+    Substructures keep the parent's atom numbers and coordinates, which is exactly
+    what chython's reactor hands back for a real disconnection.
+    """
+    target = read_smiles("CC(=O)Nc1ccccc1CCO")
+    target.clean2d()
+
+    acid = target.substructure([1, 2, 3])
+    amine = target.substructure([4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    aniline = amine.substructure([4, 5, 6, 7, 8, 9, 10])
+    alcohol = amine.substructure([11, 12, 13])
+
+    _scramble(acid, 0.7, False, (12.0, -4.0))
+    _scramble(amine, 2.4, True, (-6.0, 9.0))
+    _scramble(aniline, 1.1, True, (3.0, 3.0))
+    _scramble(alcohol, -2.0, False, (-1.0, 7.0))
+
+    # synthesis_route order: leaf first
+    return target, [
+        Reaction([aniline, alcohol], [amine]),
+        Reaction([acid, amine], [target]),
+    ]
+
+
+def test_align_route_puts_every_precursor_back_in_the_target_frame():
+    target, steps = _route()
+    precursors = [m for step in steps for m in step.reactants]
+
+    before = [_mean_dist(m, target) for m in precursors]
+    assert min(before) > 0.3, before
+
+    report = align_route(steps)
+
+    assert [s["mode"] for s in report] == ["rigid"] * 4
+    assert all(s["after"] < 1e-6 < s["before"] for s in report), report
+    # the cascade must run target first, or the deeper precursors inherit a frame
+    # that is itself still scrambled
+    assert all(_mean_dist(m, target) < 1e-6 for m in precursors)
+
+
+def test_align_molecule_leaves_a_single_shared_atom_alone():
+    ref = read_smiles("CCO")
+    ref.clean2d()
+    mol = read_smiles("CCO")
+    mol.clean2d()
+    mol._atoms = {1: mol._atoms[1]}
+    mol._bonds = {1: {}}
+    before = (mol.atom(1).x, mol.atom(1).y)
+
+    stats = align_molecule(mol, ref)
+
+    assert stats["mode"] == "underdetermined"
+    assert (mol.atom(1).x, mol.atom(1).y) == before
+
+
+def test_mirroring_redraws_the_wedges_instead_of_inverting_the_centres():
+    """Chython caches wedges derived from coordinates; a mirror must drop that cache."""
+    mol = read_smiles("CC(C)[C@@H]1CC[C@@H](C)C[C@H]1O")
+    mol.clean2d()
+    before = {(n, m): s for n, m, s in mol._wedge_map}  # warms the cache
+    assert before
+
+    apply_transform(mol, (1.0, 0.0, 0.0, -1.0), (0.0, 0.0), (0.0, 0.0))
+
+    after = {(n, m): s for n, m, s in mol._wedge_map}
+    assert set(after) == set(before)
+    assert all(after[k] == -s for k, s in before.items()), (before, after)

--- a/tests/unit/test_results_report.py
+++ b/tests/unit/test_results_report.py
@@ -1,0 +1,168 @@
+"""The planning report page: self-contained, one drawing per route, numbers that agree.
+
+Everything is read back out of the rendered page, never out of the values the
+renderer happened to return.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from chython import smiles as read_smiles
+
+from synplan.chem.reaction.reactor import Reaction
+from synplan.utils.visualisation import generate_results_html
+
+# The two namespace URIs an SVG must declare. They name a standard, nothing is fetched.
+_NAMESPACES = ("http://www.w3.org/2000/svg", "http://www.w3.org/1999/xlink")
+
+_NUM = r"(-?[\d.]+)"
+_DISC = re.compile(
+    rf'<circle cx="{_NUM}" cy="{_NUM}" r="10.5"[^>]*/>'
+    rf'<text x="{_NUM}" y="{_NUM}" class="sp-num">(\d+)</text>'
+)
+_RECT = re.compile(
+    rf'<rect x="{_NUM}" y="{_NUM}" width="{_NUM}" height="{_NUM}"[^>]*/>'
+)
+_TARGET_CAPTION = re.compile(
+    rf'<text x="{_NUM}" y="{_NUM}" class="sp-tag" fill="[^"]*">TARGET</text>'
+)
+_STEP_NUMBER = re.compile(r'<div class="disc">(\d+)</div>')
+
+
+class _FakeTree:
+    """A two-route tree whose precursors are real substructures of the target.
+
+    A substructure keeps its parent's atom numbers and coordinates, which is what
+    chython's reactor hands back for a real disconnection — so alignment, depiction
+    and layout all see the same shapes they see in a planning run.
+    """
+
+    def __init__(self) -> None:
+        target = read_smiles("CC(=O)Nc1ccccc1CCO")
+        target.clean2d()
+        acid = target.substructure([1, 2, 3])
+        amine = target.substructure([4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+        aniline = amine.substructure([4, 5, 6, 7, 8, 9, 10])
+        alcohol = amine.substructure([11, 12, 13])
+        ring = target.substructure([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        tail = target.substructure([11, 12, 13])
+
+        self.target = target
+        self._routes = {
+            3: (
+                Reaction([aniline, alcohol], [amine]),
+                Reaction([acid, amine], [target]),
+            ),
+            5: (Reaction([ring, tail], [target]),),
+        }
+        self.building_blocks = frozenset(str(m) for m in (acid, aniline, alcohol, tail))
+        self.nodes = {i: _FakeNode(target if i == 1 else None) for i in (1, 2, 3, 5)}
+        self.parents = {1: 0, 2: 1, 3: 2, 5: 1}
+        self.winning_nodes = [3, 5]
+        self.visited_nodes = [1, 2, 3, 5]
+        self.curr_time = 1.2345
+
+    def __len__(self) -> int:
+        return len(self.nodes)
+
+    def synthesis_route(self, node_id: int):
+        return self._routes[node_id]
+
+    def route_score(self, node_id: int) -> float:
+        return 0.5
+
+
+class _FakeNode:
+    def __init__(self, molecule) -> None:
+        self.curr_precursor = molecule
+
+    def is_solved(self) -> bool:
+        return True
+
+
+@pytest.fixture(scope="module")
+def page(tmp_path_factory) -> str:
+    path = tmp_path_factory.mktemp("report") / "report.html"
+    assert generate_results_html(_FakeTree(), str(path)) is None
+    return path.read_text(encoding="utf-8")
+
+
+def sections(page: str) -> list[str]:
+    return page.split('<section class="route card">')[1:]
+
+
+def drawing(section: str) -> str:
+    return section.split('<div class="draw">')[1].split("</div>")[0]
+
+
+def test_page_is_self_contained(page):
+    """No stylesheet, script or font to fetch: the file works with no network."""
+    for namespace in _NAMESPACES:
+        page = page.replace(namespace, "")
+    assert "http://" not in page
+    assert "https://" not in page
+    assert "<script" not in page
+
+
+def test_page_keeps_the_run_summary(page):
+    tree = _FakeTree()
+    assert "Predicted Paths Report" in page
+    assert "Retrosynthetic routes report" in page
+    assert str(tree.target) in page
+    for label, value in (
+        ("Tree size", len(tree)),
+        ("Visited nodes", len(tree.visited_nodes)),
+        ("Found paths", len(tree.winning_nodes)),
+        ("Time", round(tree.curr_time, 4)),
+    ):
+        assert label in page
+        assert f">{value}<" in page
+    for role in ("Target molecule", "Intermediate", "Not in stock", "In stock"):
+        assert role in page
+
+
+def test_one_drawing_per_route(page):
+    tree = _FakeTree()
+    found = sections(page)
+    assert len(found) == len(tree.winning_nodes)
+    for node_id, section in zip(tree.winning_nodes, found):
+        assert f'<div class="v id">{node_id}</div>' in section
+        assert drawing(section).startswith("<svg ")
+        assert drawing(section).count('viewBox="0 0 ') == 1
+        assert f'<div class="v">{len(tree.synthesis_route(node_id))}</div>' in section
+        assert "Cumulated nodes&#39; value" in section
+
+
+def test_step_numbers_match_the_discs(page):
+    tree = _FakeTree()
+    for node_id, section in zip(tree.winning_nodes, sections(page)):
+        n_steps = len(tree.synthesis_route(node_id))
+        discs = _DISC.findall(drawing(section))
+        assert [int(d[4]) for d in discs] == list(range(1, n_steps + 1))
+        assert [int(n) for n in _STEP_NUMBER.findall(section)] == [
+            int(d[4]) for d in discs
+        ]
+
+
+def test_disc_one_is_the_cut_from_the_target(page):
+    """Read from the drawing: disc 1's arrow ends on the box captioned TARGET."""
+    for section in sections(page):
+        svg = drawing(section)
+        caption = _TARGET_CAPTION.search(svg)
+        assert caption is not None
+        box_x, box_y = float(caption.group(1)) - 1, float(caption.group(2)) + 5
+
+        target_box = [
+            r
+            for r in _RECT.findall(svg)
+            if abs(float(r[0]) - box_x) < 0.11 and abs(float(r[1]) - box_y) < 0.11
+        ]
+        assert len(target_box) == 1
+        _, _, _, height = (float(v) for v in target_box[0])
+
+        cx, cy, _, _, number = next(iter(_DISC.findall(svg)))
+        assert int(number) == 1
+        assert float(cx) < box_x  # the disc sits in the lane left of the target
+        assert abs(float(cy) - (box_y + height / 2)) < 0.11

--- a/tests/unit/test_routelayout.py
+++ b/tests/unit/test_routelayout.py
@@ -1,0 +1,225 @@
+"""Invariants the tidy-tree layout must hold for any route, however shaped."""
+
+from __future__ import annotations
+
+import random
+import sys
+
+import pytest
+
+from synplan.utils.routelayout import Node, edges, layout, walk
+
+
+def boxes(root: Node) -> list[tuple[float, float, float, float, Node]]:
+    return [(n.x, n.y, n.x + n.w, n.y + n.h, n) for n in [root, *walk(root)]]
+
+
+def overlaps(root: Node) -> list[tuple[str, str]]:
+    placed, bad = boxes(root), []
+    for i, a in enumerate(placed):
+        for c in placed[i + 1 :]:
+            if (
+                a[0] < c[2] - 1e-9
+                and c[0] < a[2] - 1e-9
+                and a[1] < c[3] - 1e-9
+                and c[1] < a[3] - 1e-9
+            ):
+                bad.append((a[4].key, c[4].key))
+    return bad
+
+
+def edge_hits(root: Node, col_x: dict, col_w: dict) -> list[tuple[str, str]]:
+    """Every connector segment that crosses the interior of some box."""
+    placed, bad = boxes(root), []
+    for edge in edges(root, col_x, col_w):
+        lane, (px, py) = edge["lane"], edge["parent"]
+        segments = [((lane, py), (px, py))]
+        for cx, cy in edge["children"]:
+            segments += [((cx, cy), (lane, cy)), ((lane, cy), (lane, py))]
+        for (x1, y1), (x2, y2) in segments:
+            lo_x, hi_x = min(x1, x2), max(x1, x2)
+            lo_y, hi_y = min(y1, y2), max(y1, y2)
+            for bx1, by1, bx2, by2, node in placed:
+                if (
+                    hi_x - 1e-6 <= bx1
+                    or lo_x + 1e-6 >= bx2
+                    or hi_y - 1e-6 <= by1
+                    or lo_y + 1e-6 >= by2
+                ):
+                    continue
+                bad.append((edge["node"].key, node.key))
+    return bad
+
+
+def finite(root: Node) -> bool:
+    return all(v == v and abs(v) < 1e9 for n in [root, *walk(root)] for v in (n.x, n.y))
+
+
+def lanes_inside_gap(root: Node, col_x: dict, col_w: dict) -> bool:
+    """Every lane sits strictly inside the empty gap between two columns.
+
+    A degenerate picture with everything collapsed onto one point passes every
+    no-overlap test vacuously; it fails this one.
+    """
+    for edge in edges(root, col_x, col_w):
+        node = edge["node"]
+        right = col_x[node.depth + 1] + col_w[node.depth + 1]
+        if not right < edge["lane"] < node.x:
+            return False
+    return True
+
+
+def bbox_inside(root: Node, width: float, height: float) -> bool:
+    placed = boxes(root)
+    return (
+        min(x1 for x1, *_ in placed) >= -1e-6
+        and min(y1 for _, y1, *_ in placed) >= -1e-6
+        and max(x2 for _, _, x2, *_ in placed) <= width + 1e-6
+        and max(y2 for *_, y2, _ in placed) <= height + 1e-6
+    )
+
+
+def assert_well_formed(root: Node, **kwargs) -> None:
+    width, height, col_x, col_w = layout(root, **kwargs)
+    assert overlaps(root) == []
+    assert edge_hits(root, col_x, col_w) == []
+    assert finite(root)
+    assert bbox_inside(root, width, height)
+    assert lanes_inside_gap(root, col_x, col_w)
+
+
+def leaf(key: str, w: float = 100, h: float = 60) -> Node:
+    return Node(key, w, h)
+
+
+def chain(n: int, w: float = 90, h: float = 50) -> Node:
+    root = current = Node("c0", w, h)
+    for i in range(1, n):
+        current.children = [Node(f"c{i}", w, h)]
+        current = current.children[0]
+    return root
+
+
+WELL_FORMED = {
+    # A lone target is a valid route; the canvas is exactly its box.
+    "single node": Node("T", 200, 120),
+    "chain depth 12": chain(12),
+    "8 siblings": Node(
+        "T", 150, 90, [leaf(f"s{i}", 80 + i * 20, 40 + i * 15) for i in range(8)]
+    ),
+    "30-sibling fan, sizes 5..600": Node(
+        "T", 150, 90, [leaf(f"f{i}", 5 + i * 20, 5 + (i % 7) * 60) for i in range(30)]
+    ),
+    # A parent taller than its whole child stack is centred, and the recentring
+    # never pushes it above the row it was given.
+    "parent far taller than children": Node(
+        "T", 200, 700, [leaf("a", 90, 40), leaf("b", 90, 40)]
+    ),
+    "parent taller than children combined": Node(
+        "T", 120, 1000, [leaf("a", 90, 40), leaf("b", 90, 40), leaf("c", 90, 40)]
+    ),
+    "tiny leaf beside huge leaf": Node(
+        "T", 150, 90, [leaf("tiny", 20, 14), leaf("huge", 700, 520)]
+    ),
+    # A zero-size box is degenerate but legal: it must not collapse its column.
+    "zero-size node": Node("T", 150, 90, [leaf("z", 0, 0), leaf("b", 90, 60)]),
+    "zero width, real height": Node(
+        "T", 150, 90, [leaf("z", 0, 60), leaf("b", 90, 60)]
+    ),
+    "zero height, real width": Node(
+        "T", 150, 90, [leaf("z", 100, 0), leaf("b", 90, 60)]
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(WELL_FORMED))
+def test_layout_is_well_formed(name):
+    assert_well_formed(WELL_FORMED[name])
+
+
+def _cycle() -> Node:
+    node = Node("A", 100, 60)
+    node.children = [Node("B", 100, 60, [node])]
+    return node
+
+
+def _self_child() -> Node:
+    node = Node("S", 100, 60)
+    node.children = [node]
+    return node
+
+
+def _self_ancestor() -> Node:
+    node = Node("X", 100, 60)
+    node.children = [Node("Y", 100, 60, [Node("Z", 100, 60, [node])])]
+    return node
+
+
+def _shared_sibling() -> Node:
+    shared = leaf("shared", 100, 60)
+    return Node("T", 150, 90, [shared, shared])
+
+
+def _shared_across_branches() -> Node:
+    shared = leaf("shared", 100, 60)
+    return Node(
+        "T", 150, 90, [Node("L", 100, 60, [shared]), Node("R", 100, 60, [shared])]
+    )
+
+
+# Sizes come from an outside renderer and are not trusted: anything that is not a
+# finite, non-negative number must raise rather than place a box at NaN (invisible)
+# or with its right edge inside the connector corridor. Anything reachable twice
+# must raise too — placing it twice draws one box over another, and before the
+# guard a cyclic input ate RAM until the OOM killer arrived.
+REJECTED = {
+    "NaN width": (Node("T", 150, 90, [leaf("nan", float("nan"), 60)]), {}),
+    "negative width": (Node("T", 150, 90, [leaf("neg", -40, 60)]), {}),
+    "infinite height": (Node("T", 150, 90, [leaf("inf", 90, float("inf"))]), {}),
+    "same object twice as sibling": (_shared_sibling(), {}),
+    "same object in two branches": (_shared_across_branches(), {}),
+    "cycle A->B->A": (_cycle(), {}),
+    "node is its own child": (_self_child(), {}),
+    "node is its own ancestor": (_self_ancestor(), {}),
+    # The whole no-connector-over-a-box property rests on a strictly positive column
+    # gap; a degenerate one must raise, not report a clean canvas of collapsed edges.
+    "col_gap = 0": (Node("T", 150, 90, [leaf("a", 90, 60)]), {"col_gap": 0.0}),
+    "negative row_gap": (Node("T", 150, 90, [leaf("a", 90, 60)]), {"row_gap": -5.0}),
+}
+
+
+@pytest.mark.parametrize("name", sorted(REJECTED))
+def test_layout_rejects_impossible_input(name):
+    root, kwargs = REJECTED[name]
+    with pytest.raises(ValueError):
+        layout(root, **kwargs)
+
+
+@pytest.mark.parametrize("lane_frac", [0.0, 1.0, -0.2, 1.5])
+def test_edges_reject_lane_on_a_column_edge(lane_frac):
+    root = Node("T", 150, 90, [leaf("a", 90, 60)])
+    _, _, col_x, col_w = layout(root)
+    with pytest.raises(ValueError):
+        edges(root, col_x, col_w, lane_frac=lane_frac)
+
+
+def test_deep_chain_does_not_blow_the_stack():
+    """A route is shallow, but a stack overflow here would be a crash, not a picture."""
+    limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(10000)
+    try:
+        assert_well_formed(chain(1200, 60, 40))
+    finally:
+        sys.setrecursionlimit(limit)
+
+
+def test_random_trees_are_well_formed():
+    rng = random.Random(7)
+    for _ in range(200):
+        nodes = [Node("r", rng.uniform(5, 600), rng.uniform(5, 400))]
+        for i in range(rng.randint(0, 39)):
+            parent = rng.choice(nodes)
+            child = Node(f"n{i}", rng.uniform(5, 600), rng.uniform(5, 400))
+            parent.children.append(child)
+            nodes.append(child)
+        assert_well_formed(nodes[0])


### PR DESCRIPTION
The results report loaded Bootstrap from a CDN, stacked one striped table row per route, truncated every rule name to its label box, and gave no way to tell which disconnection came first. Underneath it, `Tree.synthesis_route` laid every molecule out again and threw away the coordinates the reactor had already given it, so a precursor arrived rotated or mirrored relative to the product it came from.

**Orientation.** `synplan/utils/align2d.py` fits each precursor onto the atoms it shares with its product — a closed-form 2x2 Kabsch, mirroring only where the fit is better. Mean deviation over the ten fits of the tutorial-18 route drops from 2.08 to 0.59 bond units; determinants are exactly ±1 and bond lengths move by 3e-16. Reflection is safe because chython derives wedges from coordinates at render time, so `apply_transform` drops `_wedge_map` and the drawn configuration survives; verified on alanine, glucose, ephedrine, menthol and ampicillin through a molfile round trip that re-perceives stereo from the drawing alone.

**Layout.** A route is a tree, so the expensive half of a layered graph layout never runs: depth gives the columns, Reingold-Tilford orders the rows, and right-aligning each column keeps every connector inside the gap between two columns where no box can be. 110 lines, `dataclasses` its only import. Property-tested against cycles, aliasing, NaN and negative box sizes, a 1200-deep chain and 200 random trees.

**Report.** Same facts as before — title, target, tree size, visited nodes, found paths, time, the legend, and per route the id, step count, cumulated nodes' value, the drawing and the step list — in a header card, a stat strip and one card per route. Steps are numbered like the discs on the drawing, counting back from the target. 341 routes come to 4.3 MB with no script tag and no external request; the drawing is 33x faster to produce because it no longer re-lays-out molecules that already had coordinates.

`get_route_svg`, `get_route_svg_from_json` and `render_svg` are untouched, so notebooks, the GUI and the cluster reports keep their current output.

The legend gains a fourth entry. The old one painted intermediates with the same fill as "not in stock" and named only three roles; the new drawing distinguishes them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the results table with a self-contained, tree-oriented route report while preserving precursor orientation during route extraction.
- Adds rigid precursor-to-product alignment with optional reflection and cache invalidation.
- Adds tidy-tree layout, route SVG rendering, and shared depiction pooling.
- Updates report generation with embedded styling, route cards, numbered steps, and four molecule roles.
- Adds alignment, report, and layout tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The changed extraction, alignment, layout, SVG pooling, and report paths form a coherent implementation, and the investigated edge cases did not establish a reachable incorrect result introduced by this PR.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| synplan/mcts/tree.py | Preserves reactor-provided coordinates when extracting synthesis routes instead of unconditionally generating new 2D layouts. |
| synplan/utils/align2d.py | Adds rigid precursor alignment using shared atom-map coordinates, including optional reflection and depiction-cache invalidation. |
| synplan/utils/routedraw.py | Builds, lays out, and renders route trees with molecule-role styling and numbered disconnections. |
| synplan/utils/routelayout.py | Implements validated depth-based columns and tidy recursive subtree placement for route diagrams. |
| synplan/utils/svgslim.py | Minifies SVG markup and pools repeated molecule depictions into shared document definitions. |
| synplan/utils/visualisation.py | Reworks results-report generation into a self-contained card-based document and preserves coordinates in existing rendering paths. |
| tests/unit/test_align2d.py | Covers alignment quality, underdetermined mappings, and wedge-cache behavior after reflection. |
| tests/unit/test_results_report.py | Verifies self-containment, summary data, route drawings, and agreement between drawing discs and listed steps. |
| tests/unit/test_routelayout.py | Exercises layout validation and geometric invariants across varied route-tree shapes. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Winning tree node] --> B[Extract synthesis route]
    B --> C[Align precursors to products]
    C --> D[Orient complete route]
    D --> E[Build molecule tree]
    E --> F[Tidy-tree layout]
    F --> G[Render route SVG]
    G --> H[Pool repeated depictions]
    H --> I[Self-contained HTML report]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: write the results report as one se..."](https://github.com/laboratoire-de-chemoinformatique/synplanner/commit/30ebab23c4d3da6f0216101f6191e4dce0ec6de9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57038612)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Interfaces, configuration, and utilities](https://app.greptile.com/tagirshin/-/custom-context/knowledge-base/laboratoire-de-chemoinformatique/synplanner/-/docs/interfaces-configuration-and-utilities.md)
- Knowledge Base — [MCTS tree search execution](https://app.greptile.com/tagirshin/-/custom-context/knowledge-base/laboratoire-de-chemoinformatique/synplanner/-/docs/mcts-search-engine.md)
- Knowledge Base — [Retrosynthetic planning engine](https://app.greptile.com/tagirshin/-/custom-context/knowledge-base/laboratoire-de-chemoinformatique/synplanner/-/docs/retrosynthetic-planning.md)
</details>


<!-- /greptile_comment -->