### PR TITLE
Feat/report export zoom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: 📚Install project (incl. dev extras)
         run: |
-          uv sync --group dev --extra cpu
+          uv sync --locked --group dev --extra cpu
         shell: bash
 
       - name: ✅Run test‑suite + coverage
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          uv sync --group dev --extra cpu
+          uv sync --locked --group dev --extra cpu
       - name: ruff format
         run: uv run --no-sync ruff format --check synplan tests
       - name: ruff

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Choose an install for your workflow:
 |---|---|
 | Chemistry, data tables and analysis, and ONNX planning on CPU | `pip install SynPlanner` |
 | Curate reaction data and run atom mapping | `pip install 'SynPlanner[curation]'` |
-| Train models and export ONNX | `pip install 'SynPlanner[training]'` |
+| Train models, use tutorial notebooks, and export ONNX | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three workflows | `pip install 'SynPlanner[all]'` |
 | Use existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
 
-For notebooks, run `pip install jupyterlab ipywidgets` in the same environment.
+`training` includes JupyterLab and widgets; launch tutorials with `jupyter lab`.
+For tutorials that also prepare reaction data or run atom mapping, install
+`SynPlanner[curation,training]` or `SynPlanner[all]`.
 
 With `uv`, select a Torch backend using `cpu`, `cu126`, or `cu128`, for example
 `uv sync --no-dev --extra training --extra cu128` for CUDA 12.8 training.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Choose an install for your workflow:
 |---|---|
 | Chemistry, data tables and analysis, and ONNX planning on CPU | `pip install SynPlanner` |
 | Curate reaction data and run atom mapping | `pip install 'SynPlanner[curation]'` |
-| Train models, use notebooks, and export ONNX | `pip install 'SynPlanner[training]'` |
+| Train models and export ONNX | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three workflows | `pip install 'SynPlanner[all]'` |
 | Use existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
+
+For notebooks, run `pip install jupyterlab ipywidgets` in the same environment.
 
 With `uv`, select a Torch backend using `cpu`, `cu126`, or `cu128`, for example
 `uv sync --no-dev --extra training --extra cu128` for CUDA 12.8 training.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ synplan planning \
   --results_dir planning_results
 ```
 
-Paths above are what `synplanner-gps-mcule-molport` writes — the download command prints each one.
+The download command prints each path. If a same-name `.onnx` file exists beside a
+checkpoint on Hugging Face, it downloads that file instead; use the printed
+`ranking_policy` path for `--policy_network`. ONNX planning needs only the base install.
 
 > [!TIP]
 > **Every tutorial runs in your browser.** Open the

--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@ pip install SynPlanner
 synplan --version
 ```
 
+The base install provides chemistry tools and CPU planning with ONNX ranking models.
+Torch checkpoint inference, training, atom mapping, notebooks and the GUI are optional:
+`SynPlanner[torch]`, `SynPlanner[training]`, `SynPlanner[mapping]`,
+`SynPlanner[notebooks]`, and `SynPlanner[gui]`.
+See [ONNX export and inference](docs/configuration/policy.rst) to convert existing ranking checkpoints.
+
 ## Quick start
 
-**1.** Download pre-trained models, rules, and building blocks:
+**1.** Install Torch support for the existing published checkpoint presets, then download models, rules, and building blocks:
 
 ```bash
+pip install 'SynPlanner[torch]'
 synplan download_preset --preset synplanner-gps-mcule-molport --save_to synplan_data
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,24 @@ synplan --version
 ```
 
 The base install provides chemistry tools and CPU planning with ONNX ranking models.
-Torch checkpoint inference, training, atom mapping, notebooks and the GUI are optional:
-`SynPlanner[torch]`, `SynPlanner[training]`, `SynPlanner[mapping]`,
-`SynPlanner[notebooks]`, and `SynPlanner[gui]`.
+Choose an install for your workflow:
+
+| Workflow | Install |
+|---|---|
+| Chemistry and ONNX planning on CPU | `pip install SynPlanner` |
+| Curate reaction data, run atom mapping, and analyse data tables | `pip install 'SynPlanner[curation]'` |
+| Train models, use notebooks, and export ONNX | `pip install 'SynPlanner[training]'` |
+| Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
+| All three workflows | `pip install 'SynPlanner[all]'` |
+| Use existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
+
+With `uv`, select a Torch backend using `cpu`, `cu126`, or `cu128`, for example
+`uv sync --no-dev --extra training --extra cu128` for CUDA 12.8 training.
+Use `--extra curation --extra cu128` for GPU atom mapping, or combine `curation`
+and `training` for the full data-to-model workflow.
+For all workflows with CUDA 12.8, use `uv sync --no-dev --extra all --extra cu128`.
+These backend indexes are configured for `uv`; `pip` users should select their
+Torch build through the PyTorch package index.
 See [ONNX export and inference](docs/configuration/policy.rst) to convert existing ranking checkpoints.
 
 ## Quick start
@@ -54,7 +69,7 @@ See [ONNX export and inference](docs/configuration/policy.rst) to convert existi
 **1.** Install Torch support for the existing published checkpoint presets, then download models, rules, and building blocks:
 
 ```bash
-pip install 'SynPlanner[torch]'
+pip install 'SynPlanner[cpu]'
 synplan download_preset --preset synplanner-gps-mcule-molport --save_to synplan_data
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install SynPlanner
 synplan --version
 ```
 
-The base install provides chemistry tools and CPU planning with ONNX ranking models.
+The base install provides chemistry tools and CPU planning with ONNX policies and value networks.
 Choose an install for your workflow:
 
 | Workflow | Install |

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ pip install SynPlanner
 synplan --version
 ```
 
-The base install provides chemistry tools and CPU planning with ONNX policies and value networks.
+The base install provides chemistry tools, ChemFrame/pandas analysis, and CPU planning with ONNX policies and value networks.
 Choose an install for your workflow:
 
 | Workflow | Install |
 |---|---|
-| Chemistry and ONNX planning on CPU | `pip install SynPlanner` |
-| Curate reaction data, run atom mapping, and analyse data tables | `pip install 'SynPlanner[curation]'` |
+| Chemistry, data tables and analysis, and ONNX planning on CPU | `pip install SynPlanner` |
+| Curate reaction data and run atom mapping | `pip install 'SynPlanner[curation]'` |
 | Train models, use notebooks, and export ONNX | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three workflows | `pip install 'SynPlanner[all]'` |

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -12,13 +12,13 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON=/usr/local/bin/python3 \
     UV_PROJECT_ENVIRONMENT=/app
 
-# Pre-sync dependencies with CPU-only torch (from optional-dependencies)
+# Pre-sync runtime dependencies for ONNX planning on CPU
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync \
         --locked \
-        --extra cpu \
+        --no-dev \
         --no-install-project
 
 # Install the project into the prepared environment
@@ -27,7 +27,7 @@ WORKDIR /src
 RUN --mount=type=cache,target=/root/.cache \
     uv sync \
         --locked \
-        --extra cpu \
+        --no-dev \
         --no-editable
 
 FROM python:3.12-slim

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -14,7 +14,7 @@ from a source checkout:
 
 .. code-block:: bash
 
-   uv sync --no-dev --extra cpu --extra onnx-export
+   uv sync --no-dev --extra cpu --extra training
    uv run --no-sync python -m scripts.export_policy_onnx ranking.ckpt ranking.onnx
 
 Use the exported file with the existing policy loader or as ``weights_path``
@@ -29,17 +29,24 @@ in the planning configuration:
 The export handles one molecule per call with variable atom and bond counts.
 Use the same ordered reaction-rule library as the checkpoint. Planning with
 ``.onnx`` weights uses NumPy and ONNX Runtime and does not require Torch.
-The ``onnx-export`` extra is only needed when exporting. For preset entries ending
+The ``training`` extra includes the export tools. For preset entries ending
 in ``.ckpt``, ``download_preset`` checks Hugging Face for a same-name ``.onnx`` file
 in the same folder and downloads it instead when available. Use the returned
 ``paths["ranking_policy"]`` (or the path printed by the CLI). If no ONNX file exists,
-the original checkpoint is downloaded; export it once or install ``SynPlanner[torch]``
+the original checkpoint is downloaded; export it once or install ``SynPlanner[cpu]``
 to use it. Filtering checkpoints are not supported by this exporter.
 
-Training requires ``SynPlanner[training]``; neural atom mapping requires
-``SynPlanner[mapping]``. Notebook tables and plots require ``SynPlanner[notebooks]``,
-and the Streamlit application requires ``SynPlanner[gui]``. The ``cpu``, ``cu126``
-and ``cu128`` extras select a Torch build for optional Torch workflows.
+``SynPlanner[curation]`` covers reaction data preparation and neural atom mapping
+with Torch, Chytorch, SciPy, and data tables. ``SynPlanner[training]`` covers model
+training, notebooks, and ONNX export, including Lightning and AdaBelief.
+``SynPlanner[gui]`` adds the Streamlit planning interface.
+``SynPlanner[all]`` includes all three workflows.
+With ``uv``, combine ``curation``, ``training``, or ``all`` with ``cpu``, ``cu126``,
+or ``cu128`` to select a Torch backend, for example
+``uv sync --no-dev --extra curation --extra cu128`` for GPU mapping or
+``uv sync --no-dev --extra training --extra cu128`` for GPU training.
+Backend indexes are configured
+for ``uv``; ``pip`` users select the Torch build through the PyTorch package index.
 
 Download example configuration
 ------------------------------
@@ -265,14 +272,13 @@ Every backend except ``csv`` needs a package SynPlanner does not depend on:
     ============== ==========================================================
     csv            nothing to install
     tensorboard    ``pip install tensorboard`` (or ``tensorboardX``) — there is no SynPlanner extra for it
-    mlflow         ``SynPlanner[mlflow]`` or ``SynPlanner[loggers]``; with ``uv``: ``uv sync --extra mlflow``
-    wandb          ``SynPlanner[wandb]`` or ``SynPlanner[loggers]``; with ``uv``: ``uv sync --extra wandb``
-    litlogger      ``pip install litlogger`` — there is no ``litlogger`` extra, and ``SynPlanner[loggers]`` covers only mlflow + wandb
+    mlflow         ``pip install mlflow``
+    wandb          ``pip install wandb``
+    litlogger      ``pip install litlogger``
     ============== ==========================================================
 
-The only extras SynPlanner defines for logging are ``mlflow``, ``wandb`` and
-``loggers`` (= mlflow + wandb). ``uv sync --extra litlogger`` and
-``uv sync --extra tensorboard`` both fail with "Extra ... is not defined".
+Install the tracking backend you use directly; SynPlanner does not define
+logger-specific extras. In a ``uv`` project, use ``uv add mlflow`` or ``uv add wandb``.
 
 You can also enable a logger from the command line without editing the YAML file:
 
@@ -349,7 +355,7 @@ for all available parameters.
         dataset: uspto_full
         policy: gps_g
 
-**MLflow logger** (requires ``SynPlanner[mlflow]`` or ``SynPlanner[loggers]``)
+**MLflow logger** (requires ``pip install mlflow``)
 
 Logs to an `MLflow <https://mlflow.org>`_ tracking server. See the
 `MLFlowLogger docs <https://lightning.ai/docs/pytorch/stable/extensions/generated/lightning.pytorch.loggers.MLFlowLogger.html>`_
@@ -372,7 +378,7 @@ for all available parameters.
       tracking_uri: http://localhost:5000
       run_name: gps-embedder-v1
 
-**Weights & Biases logger** (requires ``SynPlanner[wandb]`` or ``SynPlanner[loggers]``)
+**Weights & Biases logger** (requires ``pip install wandb``)
 
 Logs to `Weights & Biases <https://wandb.ai/>`_. See the
 `WandbLogger docs <https://lightning.ai/docs/pytorch/stable/extensions/generated/lightning.pytorch.loggers.WandbLogger.html>`_

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -6,6 +6,38 @@ Policy network
 
 The ranking or filtering policy network architecture and training hyperparameters can be adjusted in the training configuration file.
 
+ONNX ranking inference on CPU
+-----------------------------
+
+The base installation includes CPU ONNX inference. Install the optional export tools, then export a ranking checkpoint
+from a source checkout:
+
+.. code-block:: bash
+
+   uv sync --no-dev --extra cpu --extra onnx-export
+   uv run --no-sync python -m scripts.export_policy_onnx ranking.ckpt ranking.onnx
+
+Use the exported file with the existing policy loader or as ``weights_path``
+in the planning configuration:
+
+.. code-block:: python
+
+   from synplan.utils.loading import load_policy_function
+
+   policy = load_policy_function(weights_path="ranking.onnx", top_rules=50)
+
+The export handles one molecule per call with variable atom and bond counts.
+Use the same ordered reaction-rule library as the checkpoint. Planning with
+``.onnx`` weights uses NumPy and ONNX Runtime and does not require Torch.
+The ``onnx-export`` extra is only needed when exporting. Existing downloaded
+presets contain ``.ckpt`` weights: export them once, or install ``SynPlanner[torch]``
+to keep using those checkpoints. Filtering checkpoints are not supported by this exporter.
+
+Training requires ``SynPlanner[training]``; neural atom mapping requires
+``SynPlanner[mapping]``. Notebook tables and plots require ``SynPlanner[notebooks]``,
+and the Streamlit application requires ``SynPlanner[gui]``. The ``cpu``, ``cu126``
+and ``cu128`` extras select a Torch build for optional Torch workflows.
+
 Download example configuration
 ------------------------------
 

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -51,7 +51,8 @@ The existing value-network evaluation configuration accepts the exported
 ``SynPlanner[curation]`` covers reaction data preparation and neural atom mapping
 with Torch, Chytorch, and SciPy. ChemFrame and pandas analysis are included in the
 base installation. ``SynPlanner[training]`` covers model
-training, notebooks, and ONNX export, including Lightning and AdaBelief.
+training and ONNX export, including Lightning and AdaBelief.
+For notebooks, run ``pip install jupyterlab ipywidgets`` in the same environment.
 ``SynPlanner[gui]`` adds the Streamlit planning interface.
 ``SynPlanner[all]`` includes all three workflows.
 With ``uv``, combine ``curation``, ``training``, or ``all`` with ``cpu``, ``cu126``,

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -29,9 +29,12 @@ in the planning configuration:
 The export handles one molecule per call with variable atom and bond counts.
 Use the same ordered reaction-rule library as the checkpoint. Planning with
 ``.onnx`` weights uses NumPy and ONNX Runtime and does not require Torch.
-The ``onnx-export`` extra is only needed when exporting. Existing downloaded
-presets contain ``.ckpt`` weights: export them once, or install ``SynPlanner[torch]``
-to keep using those checkpoints. Filtering checkpoints are not supported by this exporter.
+The ``onnx-export`` extra is only needed when exporting. For preset entries ending
+in ``.ckpt``, ``download_preset`` checks Hugging Face for a same-name ``.onnx`` file
+in the same folder and downloads it instead when available. Use the returned
+``paths["ranking_policy"]`` (or the path printed by the CLI). If no ONNX file exists,
+the original checkpoint is downloaded; export it once or install ``SynPlanner[torch]``
+to use it. Filtering checkpoints are not supported by this exporter.
 
 Training requires ``SynPlanner[training]``; neural atom mapping requires
 ``SynPlanner[mapping]``. Notebook tables and plots require ``SynPlanner[notebooks]``,

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -6,10 +6,10 @@ Policy network
 
 The ranking or filtering policy network architecture and training hyperparameters can be adjusted in the training configuration file.
 
-ONNX ranking inference on CPU
------------------------------
+ONNX inference on CPU
+---------------------
 
-The base installation includes CPU ONNX inference. Install the optional export tools, then export a ranking checkpoint
+The base installation includes CPU ONNX inference. Install the optional export tools, then export a ranking or filtering checkpoint
 from a source checkout:
 
 .. code-block:: bash
@@ -34,7 +34,19 @@ in ``.ckpt``, ``download_preset`` checks Hugging Face for a same-name ``.onnx`` 
 in the same folder and downloads it instead when available. Use the returned
 ``paths["ranking_policy"]`` (or the path printed by the CLI). If no ONNX file exists,
 the original checkpoint is downloaded; export it once or install ``SynPlanner[cpu]``
-to use it. Filtering checkpoints are not supported by this exporter.
+to use it. Filtering exports retain both rule and priority heads; load them with
+``policy_type="filtering"`` and their original ordered rule library. The legacy
+article filtering model is incompatible with the GPS rule library. MHN models
+are not supported by this exporter.
+
+To export a value network, pass ``--value``:
+
+.. code-block:: bash
+
+   uv run --no-sync python -m scripts.export_policy_onnx value_network.ckpt value_network.onnx --value
+
+The existing value-network evaluation configuration accepts the exported
+``.onnx`` path and runs it on CPU without Torch.
 
 ``SynPlanner[curation]`` covers reaction data preparation and neural atom mapping
 with Torch, Chytorch, SciPy, and data tables. ``SynPlanner[training]`` covers model

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -51,8 +51,9 @@ The existing value-network evaluation configuration accepts the exported
 ``SynPlanner[curation]`` covers reaction data preparation and neural atom mapping
 with Torch, Chytorch, and SciPy. ChemFrame and pandas analysis are included in the
 base installation. ``SynPlanner[training]`` covers model
-training and ONNX export, including Lightning and AdaBelief.
-For notebooks, run ``pip install jupyterlab ipywidgets`` in the same environment.
+training, tutorial notebooks, and ONNX export, including Lightning, AdaBelief,
+JupyterLab, and widgets. Launch notebooks with ``jupyter lab``.
+Combine ``curation,training`` for tutorials that also prepare data or run atom mapping.
 ``SynPlanner[gui]`` adds the Streamlit planning interface.
 ``SynPlanner[all]`` includes all three workflows.
 With ``uv``, combine ``curation``, ``training``, or ``all`` with ``cpu``, ``cu126``,

--- a/docs/configuration/policy.rst
+++ b/docs/configuration/policy.rst
@@ -49,7 +49,8 @@ The existing value-network evaluation configuration accepts the exported
 ``.onnx`` path and runs it on CPU without Torch.
 
 ``SynPlanner[curation]`` covers reaction data preparation and neural atom mapping
-with Torch, Chytorch, SciPy, and data tables. ``SynPlanner[training]`` covers model
+with Torch, Chytorch, and SciPy. ChemFrame and pandas analysis are included in the
+base installation. ``SynPlanner[training]`` covers model
 training, notebooks, and ONNX export, including Lightning and AdaBelief.
 ``SynPlanner[gui]`` adds the Streamlit planning interface.
 ``SynPlanner[all]`` includes all three workflows.

--- a/docs/development/pr_review.rst
+++ b/docs/development/pr_review.rst
@@ -61,8 +61,8 @@ Check code against the existing project shape:
   train/validation leakage, long-tail class behavior, logger configuration,
   result directory creation, checkpointing, and GPU/CPU assumptions.
 - For logging integrations, keep optional remote services out of core
-  dependencies. Use extras such as ``SynPlanner[litlogger]``,
-  ``SynPlanner[wandb]``, ``SynPlanner[mlflow]``, or ``SynPlanner[loggers]``.
+  dependencies. Install the selected backend directly, for example with
+  ``pip install wandb``, ``pip install mlflow``, or ``pip install litlogger``.
 - Do not introduce private-library workarounds without a short comment explaining
   the dependency version or limitation being worked around.
 

--- a/docs/get_started/docker_images.rst
+++ b/docs/get_started/docker_images.rst
@@ -29,6 +29,10 @@ Pull images
 Run the CLI
 ~~~~~~~~~~~
 
+The CLI image provides chemistry tools and CPU planning with ONNX weights.
+The GUI image adds Streamlit. Training and neural atom mapping dependencies are
+optional package extras and are not included in these runtime images.
+
 Show help:
 
 .. code-block:: bash
@@ -50,14 +54,14 @@ repository or fetch the file first:
 .. code-block:: bash
 
    docker run --rm --platform linux/amd64 \
-     -v "$(pwd)":/app -w /app \
+     -v "$(pwd)":/workspace -w /workspace \
      ghcr.io/laboratoire-de-chemoinformatique/synplanner:${VERSION}-cli-amd64 \
      planning \
        --config configs/planning_standard.yaml \
        --targets targets.smi \
        --reaction_rules synplan_data/policy/supervised_gps/v1/reaction_rules.tsv \
        --building_blocks synplan_data/building_blocks/mcule-molport-2026-08/building_blocks.json.gz \
-       --policy_network synplan_data/policy/supervised_gps/v1/v1/ranking_policy.ckpt \
+       --policy_network synplan_data/policy/supervised_gps/v1/v1/ranking_policy.onnx \
        --results_dir planning_results
 
 Run the GUI

--- a/docs/get_started/installation.rst
+++ b/docs/get_started/installation.rst
@@ -36,6 +36,12 @@ Use a virtual environment.
 
    pip install SynPlanner
 
+The base package includes chemistry tools, ChemFrame/pandas analysis, and CPU
+planning with ONNX weights. Add ``SynPlanner[curation]`` for reaction data
+preparation and atom mapping, ``SynPlanner[training]`` for training and ONNX
+export, ``SynPlanner[gui]`` for Streamlit, or ``SynPlanner[all]`` for all three.
+For notebooks, also run ``pip install jupyterlab ipywidgets``.
+
 Verify:
 
 .. code-block:: bash
@@ -62,14 +68,14 @@ From source with uv (dev)
 
    git clone https://github.com/Laboratoire-de-Chemoinformatique/SynPlanner.git
    cd SynPlanner/
-   uv sync --extra cpu   # add "--group docs --group dev" if you need docs or dev extras
+   uv sync --extra cpu   # includes the dev group; add --group docs to build docs
    uv run synplan --help
 
 Selecting a PyTorch build
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Most users do not need to think about this: the default PyTorch wheel for your
-platform is installed automatically and works.
+The base ONNX installation does not require PyTorch. Choose a Torch build for
+training, neural atom mapping, or inference with existing ``.ckpt`` weights.
 
 If you need a specific build (CPU-only on a GPU machine, or a particular CUDA
 version), how you select it depends on the installer.
@@ -82,15 +88,12 @@ version), how you select it depends on the installer.
    uv sync --extra cu126    # CUDA 12.6
    uv sync --extra cu128    # CUDA 12.8
 
-**With pip**, these extras change nothing. ``pip install "SynPlanner[cpu]"``
-succeeds — pip accepts the extra — but all it adds is ``torch>=2.0``, which is
-already satisfied by the transitive requirement from ``chytorch-synplan``,
-``torch-geometric`` and ``pytorch-lightning``. The index mapping that gives the
-extras their meaning lives in ``[tool.uv.sources]`` and ``[[tool.uv.index]]``,
-which pip does not read, so torch is resolved from PyPI either way. The result is
-identical to a plain ``pip install SynPlanner``. To control the build with pip, install ``torch`` from the
+**With pip**, the backend extras install Torch and PyG, but do not select a
+CPU or CUDA wheel index. The index mapping lives in ``[tool.uv.sources]`` and
+``[[tool.uv.index]]``, which pip does not read. To control the build with pip,
+install ``torch`` from the
 `PyTorch install selector <https://pytorch.org/get-started/locally/>`_ first, then
-install SynPlanner.
+install the SynPlanner workflow extra you need.
 
 To check what you ended up with:
 

--- a/docs/get_started/installation.rst
+++ b/docs/get_started/installation.rst
@@ -38,9 +38,11 @@ Use a virtual environment.
 
 The base package includes chemistry tools, ChemFrame/pandas analysis, and CPU
 planning with ONNX weights. Add ``SynPlanner[curation]`` for reaction data
-preparation and atom mapping, ``SynPlanner[training]`` for training and ONNX
+preparation and atom mapping, ``SynPlanner[training]`` for training, tutorial notebooks, and ONNX
 export, ``SynPlanner[gui]`` for Streamlit, or ``SynPlanner[all]`` for all three.
-For notebooks, also run ``pip install jupyterlab ipywidgets``.
+The ``training`` extra includes JupyterLab and widgets; launch tutorials with
+``jupyter lab``. Use ``SynPlanner[curation,training]`` or ``SynPlanner[all]``
+for tutorials that also prepare reaction data or run atom mapping.
 
 Verify:
 

--- a/docs/user_guide/cli_interface.rst
+++ b/docs/user_guide/cli_interface.rst
@@ -269,12 +269,11 @@ types of policy networks is configured by the same configuration file (see the d
     - ``--workers`` - CPU workers for ranking dataset preprocessing (0 = auto).
     - ``--no-cache`` - disable dataset cache reuse.
     - ``--logger`` - logger backend: ``csv``, ``tensorboard``, ``mlflow``, ``wandb``, or ``litlogger``.
-      ``csv`` and ``tensorboard`` work out of the box; ``wandb`` and ``mlflow``
-      need ``SynPlanner[wandb]``, ``SynPlanner[mlflow]`` or ``SynPlanner[loggers]``.
+      ``csv`` works out of the box. Install other backends directly with
+      ``pip install tensorboard``, ``pip install wandb``, or ``pip install mlflow``.
       ``litlogger`` needs ``pytorch-lightning>=2.6.1`` (which is where the
-      ``LitLogger`` class lives) plus ``pip install litlogger``. There is no
-      ``SynPlanner[litlogger]`` extra — ``pip`` only warns and installs nothing
-      when you ask for one — and ``SynPlanner[loggers]`` covers wandb + mlflow only.
+      ``LitLogger`` class lives) plus ``pip install litlogger``. SynPlanner does not
+      define logger-specific extras.
 
 **MHN ranking policy tuning**
 
@@ -306,12 +305,11 @@ types of policy networks is configured by the same configuration file (see the d
     - ``--num_cpus`` - CPUs for filtering dataset preparation.
     - ``--no-cache`` - disable dataset cache reuse.
     - ``--logger`` - logger backend: ``csv``, ``tensorboard``, ``mlflow``, ``wandb``, or ``litlogger``.
-      ``csv`` and ``tensorboard`` work out of the box; ``wandb`` and ``mlflow``
-      need ``SynPlanner[wandb]``, ``SynPlanner[mlflow]`` or ``SynPlanner[loggers]``.
+      ``csv`` works out of the box. Install other backends directly with
+      ``pip install tensorboard``, ``pip install wandb``, or ``pip install mlflow``.
       ``litlogger`` needs ``pytorch-lightning>=2.6.1`` (which is where the
-      ``LitLogger`` class lives) plus ``pip install litlogger``. There is no
-      ``SynPlanner[litlogger]`` extra — ``pip`` only warns and installs nothing
-      when you ask for one — and ``SynPlanner[loggers]`` covers wandb + mlflow only.
+      ``LitLogger`` class lives) plus ``pip install litlogger``. SynPlanner does not
+      define logger-specific extras.
 
 Value network training
 ---------------------------

--- a/gui.Dockerfile
+++ b/gui.Dockerfile
@@ -12,13 +12,14 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON=/usr/local/bin/python3 \
     UV_PROJECT_ENVIRONMENT=/app
 
-# Pre-sync dependencies with CPU-only torch (from optional-dependencies)
+# Pre-sync runtime dependencies for ONNX planning on CPU
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync \
         --locked \
-        --extra cpu \
+        --no-dev \
+        --extra gui \
         --no-install-project
 
 # Install the project into the prepared environment
@@ -27,7 +28,8 @@ WORKDIR /src
 RUN --mount=type=cache,target=/root/.cache \
     uv sync \
         --locked \
-        --extra cpu \
+        --no-dev \
+        --extra gui \
         --no-editable
 
 FROM python:3.12-slim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 dependencies = [
   "chython-synplan[racer-default]==1.108",
   "numpy>=2",
-  "onnxruntime>=1.23",
+  "onnxruntime>=1.23,<1.24; python_version < '3.11'", # 1.24 has no Python 3.10 wheels.
+  "onnxruntime>=1.23; python_version >= '3.11'",
   "tqdm>=4.66",
   "click>=8.0.0",
   "huggingface-hub>=0.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "pyyaml>=6.0",
   "frozendict>=2.4.6",
   "ijson>=3.4.0",
+  "protobuf>=6.0",
 ]
 
 # Optional workflows; the base installation runs ONNX policies on CPU.
@@ -47,9 +48,8 @@ training = [
   "torch-geometric>=2.4.0",
   "adabelief-pytorch>=0.2.1",
   "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
+  "torchmetrics>=1.0",
   "safetensors>=0.4",
-  "ipykernel>6.29.0",
-  "ipywidgets>8.1.0",
   "matplotlib>=3.7",
   "matplotlib-venn>=1.1",
   "onnx>=1.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,36 +20,40 @@ classifiers = [
 
 dependencies = [
   "chython-synplan[racer-default]==1.108",
-  "chytorch-synplan>=1.70",
-  "chytorch-rxnmap-synplan>=1.7",
   "numpy>=2",
-  "pandas>=1.4",
-  "toytree>=2.0",
+  "onnxruntime>=1.23",
+  "tqdm>=4.66",
   "click>=8.0.0",
   "huggingface-hub>=0.24.0",
-  "adabelief-pytorch>=0.2.1",
-  "torch-geometric>=2.4.0",
-  "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
-  "ipykernel>6.29.0",
-  "ipywidgets>8.1.0",
-  "streamlit>1.35.1",
-  "streamlit-ketcher>=0.0.1",
   "rdkit>=2023.9.1",
-  "matplotlib>=3.7",
-  "matplotlib-venn>=1.1",
   "pydantic>=2.0",
   "pyyaml>=6.0",
-  "safetensors>=0.4",
-  "protobuf>=6.0",
   "frozendict>=2.4.6",
   "ijson>=3.4.0",
 ]
 
-# Extras to select PyTorch variant - required for uv users
+# Optional workflows; the base installation runs ONNX policies on CPU.
 [project.optional-dependencies]
-cpu = ["torch>=2.0"]
-cu126 = ["torch>=2.0"]
-cu128 = ["torch>=2.0"]
+torch = ["torch>=2.0", "torch-geometric>=2.4.0"]
+training = [
+  "SynPlanner[torch]",
+  "adabelief-pytorch>=0.2.1",
+  "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
+  "safetensors>=0.4",
+]
+mapping = ["chytorch-synplan>=1.70", "chytorch-rxnmap-synplan>=1.7", "scipy>=1.10"]
+notebooks = [
+  "pandas>=1.4",
+  "ipykernel>6.29.0",
+  "ipywidgets>8.1.0",
+  "matplotlib>=3.7",
+  "matplotlib-venn>=1.1",
+]
+gui = ["pandas>=1.4", "streamlit>1.35.1", "streamlit-ketcher>=0.0.1"]
+onnx-export = ["SynPlanner[torch]", "torch>=2.6", "onnx>=1.17", "onnxscript>=0.5"]
+cpu = ["SynPlanner[torch]", "torch>=2.0"]
+cu126 = ["SynPlanner[torch]", "torch>=2.0"]
+cu128 = ["SynPlanner[torch]", "torch>=2.0"]
 wandb = ["wandb>=0.17"]
 mlflow = ["mlflow>=2"]
 loggers = [
@@ -59,6 +63,7 @@ loggers = [
 
 [dependency-groups]
 dev = [
+  "SynPlanner[training,mapping,notebooks,onnx-export]",
   "pytest>=9.0.3",
   "pytest-cov>=7.1.0",
   "pytest-xdist>=3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,36 +35,36 @@ dependencies = [
 
 # Optional workflows; the base installation runs ONNX policies on CPU.
 [project.optional-dependencies]
-torch = ["torch>=2.0", "torch-geometric>=2.4.0"]
+curation = [
+  "torch>=2.0",
+  "chytorch-synplan>=1.70",
+  "chytorch-rxnmap-synplan>=1.7",
+  "scipy>=1.10",
+  "pandas>=1.4",
+]
 training = [
-  "SynPlanner[torch]",
+  "torch>=2.6",
+  "torch-geometric>=2.4.0",
   "adabelief-pytorch>=0.2.1",
   "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
   "safetensors>=0.4",
-]
-mapping = ["chytorch-synplan>=1.70", "chytorch-rxnmap-synplan>=1.7", "scipy>=1.10"]
-notebooks = [
   "pandas>=1.4",
   "ipykernel>6.29.0",
   "ipywidgets>8.1.0",
   "matplotlib>=3.7",
   "matplotlib-venn>=1.1",
+  "onnx>=1.17",
+  "onnxscript>=0.5",
 ]
 gui = ["pandas>=1.4", "streamlit>1.35.1", "streamlit-ketcher>=0.0.1"]
-onnx-export = ["SynPlanner[torch]", "torch>=2.6", "onnx>=1.17", "onnxscript>=0.5"]
-cpu = ["SynPlanner[torch]", "torch>=2.0"]
-cu126 = ["SynPlanner[torch]", "torch>=2.0"]
-cu128 = ["SynPlanner[torch]", "torch>=2.0"]
-wandb = ["wandb>=0.17"]
-mlflow = ["mlflow>=2"]
-loggers = [
-  "wandb>=0.17",
-  "mlflow>=2",
-]
+all = ["SynPlanner[curation,training,gui]"]
+cpu = ["torch>=2.0", "torch-geometric>=2.4.0"]
+cu126 = ["torch>=2.0", "torch-geometric>=2.4.0"]
+cu128 = ["torch>=2.0", "torch-geometric>=2.4.0"]
 
 [dependency-groups]
 dev = [
-  "SynPlanner[training,mapping,notebooks,onnx-export]",
+  "SynPlanner[curation,training]",
   "pytest>=9.0.3",
   "pytest-cov>=7.1.0",
   "pytest-xdist>=3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ training = [
   "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
   "torchmetrics>=1.0",
   "safetensors>=0.4",
+  "jupyterlab>=4.5.7",
+  "ipywidgets>8.1.0",
   "matplotlib>=3.7",
   "matplotlib-venn>=1.1",
   "onnx>=1.17",
@@ -69,7 +71,6 @@ dev = [
   "pytest-xdist>=3.6",
   "twine>=6.2.0,<7",
   "ruff>=0.14.4,<0.15",
-  "jupyterlab>=4.5.7",
   "grpcio-tools>=1.78.0",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "chython-synplan[racer-default]==1.108",
   "numpy>=2",
+  "pandas>=1.4",
   "onnxruntime>=1.23,<1.24; python_version < '3.11'", # 1.24 has no Python 3.10 wheels.
   "onnxruntime>=1.23; python_version >= '3.11'",
   "tqdm>=4.66",
@@ -40,7 +41,6 @@ curation = [
   "chytorch-synplan>=1.70",
   "chytorch-rxnmap-synplan>=1.7",
   "scipy>=1.10",
-  "pandas>=1.4",
 ]
 training = [
   "torch>=2.6",
@@ -48,7 +48,6 @@ training = [
   "adabelief-pytorch>=0.2.1",
   "pytorch-lightning>=2.3.3,!=2.6.2,!=2.6.3",
   "safetensors>=0.4",
-  "pandas>=1.4",
   "ipykernel>6.29.0",
   "ipywidgets>8.1.0",
   "matplotlib>=3.7",
@@ -56,7 +55,7 @@ training = [
   "onnx>=1.17",
   "onnxscript>=0.5",
 ]
-gui = ["pandas>=1.4", "streamlit>1.35.1", "streamlit-ketcher>=0.0.1"]
+gui = ["streamlit>1.35.1", "streamlit-ketcher>=0.0.1"]
 all = ["SynPlanner[curation,training,gui]"]
 cpu = ["torch>=2.0", "torch-geometric>=2.4.0"]
 cu126 = ["torch>=2.0", "torch-geometric>=2.4.0"]

--- a/scripts/export_policy_onnx.py
+++ b/scripts/export_policy_onnx.py
@@ -1,4 +1,4 @@
-"""Export a ranking checkpoint: python -m scripts.export_policy_onnx IN.ckpt OUT.onnx."""
+"""Export a policy checkpoint to ONNX; pass --value for a value network."""
 
 import argparse
 from pathlib import Path
@@ -9,8 +9,12 @@ import torch
 from chython import smiles
 
 from synplan.ml.featurization.molecules import mol_to_pyg
-from synplan.ml.networks.checkpoint import load_policy_network_from_checkpoint
-from synplan.ml.networks.policy.linear import RankingPolicyNetwork
+from synplan.ml.networks.checkpoint import (
+    load_policy_network_from_checkpoint,
+    load_value_network_from_checkpoint,
+)
+from synplan.ml.networks.policy.linear import LinearPolicyNetwork
+from synplan.ml.networks.value import ValueNetwork
 
 
 class SingleGraphPool(torch.nn.Module):
@@ -24,7 +28,7 @@ class SingleGraphPool(torch.nn.Module):
         return self.pool(x, index=index, dim_size=1)
 
 
-class RankingExport(torch.nn.Module):
+class GraphExport(torch.nn.Module):
     def __init__(self, network):
         super().__init__()
         self.network = network
@@ -33,37 +37,55 @@ class RankingExport(torch.nn.Module):
         graph = SimpleNamespace(
             x=x, edge_index=edge_index, edge_attr=edge_attr, batch=None
         )
-        logits = self.network.y_predictor(self.network.embedder(graph))
+        if isinstance(self.network, ValueNetwork):
+            return self.network(graph)
+        embedding = self.network.embedder(graph)
+        logits = self.network.y_predictor(embedding)
+        if self.network.policy_type == "filtering":
+            priority = torch.sigmoid(self.network.priority_predictor(embedding))
+            return torch.sigmoid(logits), logits, priority
         return torch.softmax(logits, dim=-1), logits
 
 
-def export_policy(checkpoint, output):
+def export_policy(checkpoint, output, *, value=False):
     """Export one molecule per call, with dynamic atom and bond counts."""
     output = Path(output)
     if output.suffix != ".onnx":
         raise ValueError("Output path must end in .onnx")
-    network = load_policy_network_from_checkpoint(checkpoint)
-    if not isinstance(network, RankingPolicyNetwork):
-        raise ValueError("ONNX export currently supports linear ranking policies only")
-    if network.hparams["config"]["embedder_type"] == "gps":
+    network = (
+        load_value_network_from_checkpoint(checkpoint)
+        if value
+        else load_policy_network_from_checkpoint(checkpoint)
+    )
+    if not isinstance(network, (LinearPolicyNetwork, ValueNetwork)):
+        raise ValueError("ONNX export supports linear policies and value networks only")
+    config = network.hparams.get("config", network.hparams)
+    if config.get("embedder_type", "gcn") == "gps":
         network.embedder.pool = SingleGraphPool(network.embedder.pool)
+    outputs = ["value"] if value else ["probabilities", "logits"]
+    if not value and network.policy_type == "filtering":
+        outputs.append("priority")
     graph = mol_to_pyg(smiles("CC(=O)Oc1ccccc1C(=O)O"))
     atoms = torch.export.Dim("atoms", min=2)
     edges = torch.export.Dim("edges", min=2)
     with torch.no_grad():
         torch.onnx.export(
-            RankingExport(network).eval(),
+            GraphExport(network).eval(),
             (graph.x, graph.edge_index, graph.edge_attr),
             str(output),
             input_names=["x", "edge_index", "edge_attr"],
-            output_names=["probabilities", "logits"],
+            output_names=outputs,
             dynamic_shapes=({0: atoms}, {1: edges}, {0: edges}),
             opset_version=18,
             dynamo=True,
             external_data=False,
         )
     model = onnx.load(output)
-    metadata = {"synplan.policy": "ranking-v1"}
+    metadata = (
+        {"synplan.value": "value-v1"}
+        if value
+        else {"synplan.policy": f"{network.policy_type}-v1"}
+    )
     digest = getattr(network, "rule_vocabulary_digest", None)
     if digest is not None:
         metadata["synplan.rule_vocabulary_digest"] = digest
@@ -75,5 +97,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("checkpoint")
     parser.add_argument("output")
+    parser.add_argument("--value", action="store_true", help="Export a value network")
     args = parser.parse_args()
-    export_policy(args.checkpoint, args.output)
+    export_policy(args.checkpoint, args.output, value=args.value)

--- a/scripts/export_policy_onnx.py
+++ b/scripts/export_policy_onnx.py
@@ -1,0 +1,79 @@
+"""Export a ranking checkpoint: python -m scripts.export_policy_onnx IN.ckpt OUT.onnx."""
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import onnx
+import torch
+from chython import smiles
+
+from synplan.ml.featurization.molecules import mol_to_pyg
+from synplan.ml.networks.checkpoint import load_policy_network_from_checkpoint
+from synplan.ml.networks.policy.linear import RankingPolicyNetwork
+
+
+class SingleGraphPool(torch.nn.Module):
+    """Supply GPS pooling's graph count without extracting it from tensor values."""
+
+    def __init__(self, pool):
+        super().__init__()
+        self.pool = pool
+
+    def forward(self, x, index=None):
+        return self.pool(x, index=index, dim_size=1)
+
+
+class RankingExport(torch.nn.Module):
+    def __init__(self, network):
+        super().__init__()
+        self.network = network
+
+    def forward(self, x, edge_index, edge_attr):
+        graph = SimpleNamespace(
+            x=x, edge_index=edge_index, edge_attr=edge_attr, batch=None
+        )
+        logits = self.network.y_predictor(self.network.embedder(graph))
+        return torch.softmax(logits, dim=-1), logits
+
+
+def export_policy(checkpoint, output):
+    """Export one molecule per call, with dynamic atom and bond counts."""
+    output = Path(output)
+    if output.suffix != ".onnx":
+        raise ValueError("Output path must end in .onnx")
+    network = load_policy_network_from_checkpoint(checkpoint)
+    if not isinstance(network, RankingPolicyNetwork):
+        raise ValueError("ONNX export currently supports linear ranking policies only")
+    if network.hparams["config"]["embedder_type"] == "gps":
+        network.embedder.pool = SingleGraphPool(network.embedder.pool)
+    graph = mol_to_pyg(smiles("CC(=O)Oc1ccccc1C(=O)O"))
+    atoms = torch.export.Dim("atoms", min=2)
+    edges = torch.export.Dim("edges", min=2)
+    with torch.no_grad():
+        torch.onnx.export(
+            RankingExport(network).eval(),
+            (graph.x, graph.edge_index, graph.edge_attr),
+            str(output),
+            input_names=["x", "edge_index", "edge_attr"],
+            output_names=["probabilities", "logits"],
+            dynamic_shapes=({0: atoms}, {1: edges}, {0: edges}),
+            opset_version=18,
+            dynamo=True,
+            external_data=False,
+        )
+    model = onnx.load(output)
+    metadata = {"synplan.policy": "ranking-v1"}
+    digest = getattr(network, "rule_vocabulary_digest", None)
+    if digest is not None:
+        metadata["synplan.rule_vocabulary_digest"] = digest
+    onnx.helper.set_model_props(model, metadata)
+    onnx.save(model, output)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkpoint")
+    parser.add_argument("output")
+    args = parser.parse_args()
+    export_policy(args.checkpoint, args.output)

--- a/skills/synplanner-usage/SKILL.md
+++ b/skills/synplanner-usage/SKILL.md
@@ -92,15 +92,16 @@ Python `>=3.10,<3.15`. Use a virtual environment and choose the user's workflow:
 | --- | --- |
 | Chemistry, ChemFrame/pandas analysis, and CPU planning with ONNX weights | `pip install SynPlanner` |
 | Reaction data curation and atom mapping | `pip install 'SynPlanner[curation]'` |
-| Model training, notebooks, and ONNX export | `pip install 'SynPlanner[training]'` |
+| Model training and ONNX export | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three optional workflows | `pip install 'SynPlanner[all]'` |
 | Inference with existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
 
 The base install includes pandas for ChemFrame and general analysis and needs no
 Torch. Curation adds Torch, Chytorch's reaction mapper, and SciPy;
-training adds Torch/PyG, Lightning, AdaBelief, notebook tools,
-and the ONNX exporter. Combine `curation` and `training` for data-to-model work.
+training adds Torch/PyG, Lightning, AdaBelief, and the ONNX exporter.
+Combine `curation` and `training` for data-to-model work.
+For notebooks, run `pip install jupyterlab ipywidgets` in the same environment.
 Install a selected tracking backend directly, e.g. `pip install wandb` or
 `pip install mlflow`; there are no logger-specific SynPlanner extras.
 

--- a/skills/synplanner-usage/SKILL.md
+++ b/skills/synplanner-usage/SKILL.md
@@ -90,15 +90,16 @@ Python `>=3.10,<3.15`. Use a virtual environment and choose the user's workflow:
 
 | Workflow | Install |
 | --- | --- |
-| Chemistry and CPU planning with ONNX weights | `pip install SynPlanner` |
-| Reaction data curation, atom mapping, and data tables | `pip install 'SynPlanner[curation]'` |
+| Chemistry, ChemFrame/pandas analysis, and CPU planning with ONNX weights | `pip install SynPlanner` |
+| Reaction data curation and atom mapping | `pip install 'SynPlanner[curation]'` |
 | Model training, notebooks, and ONNX export | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three optional workflows | `pip install 'SynPlanner[all]'` |
 | Inference with existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
 
-The base install needs no Torch. Curation adds Torch, Chytorch's reaction mapper,
-SciPy, and pandas; training adds Torch/PyG, Lightning, AdaBelief, notebook tools,
+The base install includes pandas for ChemFrame and general analysis and needs no
+Torch. Curation adds Torch, Chytorch's reaction mapper, and SciPy;
+training adds Torch/PyG, Lightning, AdaBelief, notebook tools,
 and the ONNX exporter. Combine `curation` and `training` for data-to-model work.
 Install a selected tracking backend directly, e.g. `pip install wandb` or
 `pip install mlflow`; there are no logger-specific SynPlanner extras.

--- a/skills/synplanner-usage/SKILL.md
+++ b/skills/synplanner-usage/SKILL.md
@@ -92,16 +92,17 @@ Python `>=3.10,<3.15`. Use a virtual environment and choose the user's workflow:
 | --- | --- |
 | Chemistry, ChemFrame/pandas analysis, and CPU planning with ONNX weights | `pip install SynPlanner` |
 | Reaction data curation and atom mapping | `pip install 'SynPlanner[curation]'` |
-| Model training and ONNX export | `pip install 'SynPlanner[training]'` |
+| Model training, tutorial notebooks, and ONNX export | `pip install 'SynPlanner[training]'` |
 | Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
 | All three optional workflows | `pip install 'SynPlanner[all]'` |
 | Inference with existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
 
 The base install includes pandas for ChemFrame and general analysis and needs no
 Torch. Curation adds Torch, Chytorch's reaction mapper, and SciPy;
-training adds Torch/PyG, Lightning, AdaBelief, and the ONNX exporter.
+training adds Torch/PyG, Lightning, AdaBelief, JupyterLab, widgets, and the ONNX exporter.
 Combine `curation` and `training` for data-to-model work.
-For notebooks, run `pip install jupyterlab ipywidgets` in the same environment.
+Launch tutorial notebooks with `jupyter lab`. For curation or atom-mapping
+tutorials, install `SynPlanner[curation,training]` or `SynPlanner[all]`.
 Install a selected tracking backend directly, e.g. `pip install wandb` or
 `pip install mlflow`; there are no logger-specific SynPlanner extras.
 

--- a/skills/synplanner-usage/SKILL.md
+++ b/skills/synplanner-usage/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   Out of scope: building or contributing to SynPlanner itself, and general
   cheminformatics that does not involve reactions.
 license: MIT
-compatibility: Requires Python >=3.10,<3.15 and uv. GPU use requires CUDA 12.6 or 12.8.
+compatibility: Requires Python >=3.10,<3.15. Install with pip or uv. CUDA backend selectors use uv and CUDA 12.6 or 12.8.
 metadata:
   project: SynPlanner
   homepage: https://github.com/Laboratoire-de-Chemoinformatique/SynPlanner
@@ -86,11 +86,29 @@ Say so when you hand over a library. `references/tasks.md` has the specifics.
 
 ## Installing
 
-Python `>=3.10,<3.15`. Three supported paths:
+Python `>=3.10,<3.15`. Use a virtual environment and choose the user's workflow:
+
+| Workflow | Install |
+| --- | --- |
+| Chemistry and CPU planning with ONNX weights | `pip install SynPlanner` |
+| Reaction data curation, atom mapping, and data tables | `pip install 'SynPlanner[curation]'` |
+| Model training, notebooks, and ONNX export | `pip install 'SynPlanner[training]'` |
+| Streamlit planning interface | `pip install 'SynPlanner[gui]'` |
+| All three optional workflows | `pip install 'SynPlanner[all]'` |
+| Inference with existing Torch checkpoints | `pip install 'SynPlanner[cpu]'` |
+
+The base install needs no Torch. Curation adds Torch, Chytorch's reaction mapper,
+SciPy, and pandas; training adds Torch/PyG, Lightning, AdaBelief, notebook tools,
+and the ONNX exporter. Combine `curation` and `training` for data-to-model work.
+Install a selected tracking backend directly, e.g. `pip install wandb` or
+`pip install mlflow`; there are no logger-specific SynPlanner extras.
+
+From a source clone, use `--no-dev` for a user environment:
 
 ```bash
-pip install SynPlanner                 # users — recommended, use a virtualenv
-uv sync --extra cpu                    # from a source clone (dev)
+uv sync --no-dev                       # chemistry and ONNX planning
+uv sync --no-dev --extra training --extra cpu
+uv sync --extra cpu                    # contributors: includes the dev group
 docker build --platform linux/amd64 -t synplan:cli -f cli.Dockerfile .
 ```
 
@@ -106,7 +124,12 @@ synplan download_preset --preset synplanner-gps --save_to synplan_data
 ```
 
 Fetches from HuggingFace and prints a `key: path` map. Those paths are what
-`synplan planning` consumes. `download_all_data` still exists but is
+`synplan planning` consumes. For a preset entry ending in `.ckpt`, the downloader
+prefers a same-name `.onnx` file in the same remote folder when available.
+Use the printed path or the returned `paths["ranking_policy"]`; do not hardcode
+the checkpoint suffix. If no ONNX counterpart exists, it downloads the checkpoint,
+which needs `SynPlanner[cpu]` (or a CUDA extra), or can be exported using
+`SynPlanner[training]`. `download_all_data` still exists but is
 **deprecated** — do not use it.
 
 **2. `configs/*.yaml` are not installed by pip.** They live only in the git
@@ -125,7 +148,18 @@ and **network training** (`ranking_policy_training`, `filtering_policy_training`
 `mhn_network_tuning`, `value_network_tuning`). Everything else — planning, data
 curation, rule extraction, route analysis — runs on CPU, which is the typical case.
 
-If the user needs one of those two on a GPU, set it up for them: read
+With `uv` in a source clone, choose one backend: `cpu`, `cu126`, or `cu128`.
+Combine it with the workflow extra; `all` includes workflows, not a backend:
+
+```bash
+uv sync --no-dev --extra curation --extra cu128   # GPU atom mapping
+uv sync --no-dev --extra training --extra cu126  # GPU training
+uv sync --no-dev --extra all --extra cu128       # all workflows
+```
+
+The backend indexes are configured for `uv`; `pip install 'SynPlanner[cu128]'`
+alone does not select the CUDA wheel index. For a pip installation, select the
+Torch build through the PyTorch package index. If the user needs GPU setup, read
 [Selecting a PyTorch build](https://synplanner.readthedocs.io/en/latest/get_started/installation.html#selecting-a-pytorch-build)
 and run the install yourself. Do not hand the user a link and stop.
 

--- a/skills/synplanner-usage/references/tasks.md
+++ b/skills/synplanner-usage/references/tasks.md
@@ -52,6 +52,7 @@ The above, then `export_tree_to_json` and `routes_clustering_report`.
 `filter_reactions_from_file` — those two effectively always run as a pair.
 
 **"Use my own reaction data end to end"**
+Install `SynPlanner[curation,training]` (or `SynPlanner[all]`).
 Clean → `extract_rules_from_reactions` → `create_policy_dataset` +
 `run_policy_training` → planning setup with the new rules and policy.
 
@@ -210,6 +211,7 @@ CLI: `synplan download_preset`.
 Docs: `get_started/data_download`, `user_guide/data`
 
 **Clean a reaction dataset**
+Install `SynPlanner[curation]` for the mapping and curation workflow.
 `MappingConfig` + `map_reactions_from_file` (`synplan.chem.reaction.curation.mapping`), then
 `standardize_reactions_from_file`, then `filter_reactions_from_file`.
 CLI: `reaction_mapping` → `reaction_standardizing` → `reaction_filtering`.
@@ -297,7 +299,8 @@ Docs: `user_guide/cli_interface`
 
 ## Training and benchmarking
 
-Training is the one area where a GPU is worth setting up.
+Install `SynPlanner[training]`. Training and reaction mapping benefit from a GPU;
+choose the backend as described in the skill's installation instructions.
 
 **Train a ranking or filtering policy**
 `PolicyNetworkConfig` → `create_policy_dataset` → `run_policy_training`
@@ -321,7 +324,7 @@ Docs: `methods/value`, `configuration/value`
 Docs: `configuration/policy` — "Benchmark recipe".
 
 **Log training runs**
-Optional extras `wandb` / `mlflow` / `loggers`.
+Install the selected backend directly: `pip install wandb` or `pip install mlflow`.
 Docs: `configuration/policy` — "Training logger"
 
 ## Synthons (the Synt-On port)

--- a/synplan/chem/reaction/curation/__init__.py
+++ b/synplan/chem/reaction/curation/__init__.py
@@ -1,3 +1,9 @@
-from synplan.chem.reaction.curation.mapping import MappingConfig
-
 __all__ = ["MappingConfig"]
+
+
+def __getattr__(name):
+    if name == "MappingConfig":
+        from synplan.chem.reaction.curation.mapping import MappingConfig
+
+        return MappingConfig
+    raise AttributeError(name)

--- a/synplan/chem/reaction/rules/analysis.py
+++ b/synplan/chem/reaction/rules/analysis.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Sequence
 from pathlib import Path
 
-import pandas as pd
 from chython import smarts
 from chython.containers.reaction import ReactionContainer
 from chython.exceptions import IncorrectSmiles
@@ -151,6 +150,8 @@ class RuleSet:
         :return: ChemFrame with columns: rule, smarts, popularity, n_reactions.
             Use ``.df`` for the plain frame, rule objects intact.
         """
+        import pandas as pd
+
         for rule in self.rules:
             rule.clean2d()
 

--- a/synplan/interfaces/cli.py
+++ b/synplan/interfaces/cli.py
@@ -10,10 +10,6 @@ from synplan.chem.reaction.curation.filtering import (
     ReactionFilterConfig,
     filter_reactions_from_file,
 )
-from synplan.chem.reaction.curation.mapping import (
-    MappingConfig,
-    map_reactions_from_file,
-)
 from synplan.chem.reaction.curation.standardizing import (
     ReactionStandardizationConfig,
     standardize_reactions_from_file,
@@ -45,12 +41,6 @@ from synplan.ml.config import (
     PolicyNetworkConfig,
     TuningConfig,
     ValueNetworkConfig,
-)
-from synplan.ml.training.reinforcement import run_updating
-from synplan.ml.training.supervised import (
-    create_policy_dataset,
-    run_mhn_network_tuning,
-    run_policy_training,
 )
 from synplan.utils.loading import (
     download_all_data,
@@ -373,6 +363,11 @@ def reaction_mapping_cli(
     error_file,
 ):
     """Map reaction atoms using a neural attention model."""
+    from synplan.chem.reaction.curation.mapping import (
+        MappingConfig,
+        map_reactions_from_file,
+    )
+
     config = MappingConfig.from_yaml(config_path) if config_path else MappingConfig()
     if device is not None:
         config.device = device
@@ -511,6 +506,11 @@ def ranking_policy_training_cli(
     logger_type: str | None,
 ) -> None:
     """Ranking policy network training."""
+    from synplan.ml.training.supervised import (
+        create_policy_dataset,
+        run_policy_training,
+    )
+
     policy_config = PolicyNetworkConfig.from_yaml(config_path)
     policy_config.policy_type = "ranking"
     if logger_type is not None:
@@ -579,6 +579,8 @@ def mhn_network_tuning_cli(
     no_cache: bool,
 ) -> None:
     """Fine-tune an existing MHN ranking checkpoint on new policy data."""
+    from synplan.ml.training.supervised import run_mhn_network_tuning
+
     policy_config = PolicyNetworkConfig.from_yaml(config_path)
 
     run_mhn_network_tuning(
@@ -650,6 +652,10 @@ def filtering_policy_training_cli(
     logger_type: str | None,
 ):
     """Filtering policy network training."""
+    from synplan.ml.training.supervised import (
+        create_policy_dataset,
+        run_policy_training,
+    )
 
     policy_config = PolicyNetworkConfig.from_yaml(config_path)
     policy_config.policy_type = "filtering"
@@ -731,6 +737,7 @@ def value_network_tuning_cli(
     results_dir: str,
 ):
     """Value network tuning."""
+    from synplan.ml.training.reinforcement import run_updating
 
     with open(config_path, encoding="utf-8") as file:
         config = yaml.safe_load(file)

--- a/synplan/mcts/evaluation.py
+++ b/synplan/mcts/evaluation.py
@@ -3,6 +3,7 @@
 import random
 from abc import ABC, abstractmethod
 from collections import deque
+from pathlib import Path
 from random import uniform
 from typing import TYPE_CHECKING
 
@@ -359,13 +360,26 @@ class ValueNetworkEvaluationStrategy(EvaluationStrategy):
         :param weights_path: The value network weights file path.
         :param normalize: Whether to normalize scores to [0, 1].
         """
+        self.normalize = normalize
+        self.onnx_session = None
+        if Path(weights_path).suffix == ".onnx":
+            import onnxruntime as ort
+
+            options = ort.SessionOptions()
+            options.intra_op_num_threads = 1
+            self.onnx_session = ort.InferenceSession(
+                str(weights_path), options, providers=["CPUExecutionProvider"]
+            )
+            metadata = self.onnx_session.get_modelmeta().custom_metadata_map
+            if metadata.get("synplan.value") != "value-v1":
+                raise ValueError("Expected a SynPlanner ONNX value network export")
+            return
         from synplan.ml.networks.checkpoint import load_network_from_checkpoint
         from synplan.ml.networks.value import ValueNetwork
 
         self.value_network = load_network_from_checkpoint(
             ValueNetwork, weights_path, map_location="cpu"
         )
-        self.normalize = normalize
 
     def predict_value(self, precursors: list[Precursor]) -> float:
         """Predicts synthesisability for the precursors composed into one molecule.
@@ -373,11 +387,22 @@ class ValueNetworkEvaluationStrategy(EvaluationStrategy):
         :param precursors: The list of precursors.
         :return: The predicted float value ("synthesisability") of the node.
         """
+        molecule = compose_precursors(precursors=precursors, exclude_small=True)
+        if self.onnx_session is not None:
+            from synplan.ml.featurization.molecules import mol_to_numpy
+
+            arrays = mol_to_numpy(molecule)
+            if arrays is None:
+                return -1e6
+            inputs = {
+                item.name: arrays[item.name] for item in self.onnx_session.get_inputs()
+            }
+            return self.onnx_session.run(["value"], inputs)[0].item()
+
         import torch
 
         from synplan.ml.featurization.molecules import mol_to_pyg
 
-        molecule = compose_precursors(precursors=precursors, exclude_small=True)
         pyg_graph = mol_to_pyg(molecule)
         if pyg_graph:
             with torch.no_grad():

--- a/synplan/mcts/evaluation.py
+++ b/synplan/mcts/evaluation.py
@@ -6,16 +6,11 @@ from collections import deque
 from random import uniform
 from typing import TYPE_CHECKING
 
-import torch
-
 from synplan.chem import building_blocks as building_block_types
 from synplan.chem.precursor import Precursor, compose_precursors
 from synplan.chem.rdkit_utils import RDKitScore
 from synplan.chem.reaction.rules import POLICY_SOURCE_NAME
 from synplan.chem.stereo import has_stereo, has_stereo_groups
-from synplan.ml.networks.checkpoint import load_network_from_checkpoint
-from synplan.ml.networks.value import ValueNetwork
-from synplan.ml.training import mol_to_pyg
 
 if TYPE_CHECKING:
     from synplan.mcts.node import Node
@@ -364,6 +359,9 @@ class ValueNetworkEvaluationStrategy(EvaluationStrategy):
         :param weights_path: The value network weights file path.
         :param normalize: Whether to normalize scores to [0, 1].
         """
+        from synplan.ml.networks.checkpoint import load_network_from_checkpoint
+        from synplan.ml.networks.value import ValueNetwork
+
         self.value_network = load_network_from_checkpoint(
             ValueNetwork, weights_path, map_location="cpu"
         )
@@ -375,6 +373,10 @@ class ValueNetworkEvaluationStrategy(EvaluationStrategy):
         :param precursors: The list of precursors.
         :return: The predicted float value ("synthesisability") of the node.
         """
+        import torch
+
+        from synplan.ml.featurization.molecules import mol_to_pyg
+
         molecule = compose_precursors(precursors=precursors, exclude_small=True)
         pyg_graph = mol_to_pyg(molecule)
         if pyg_graph:

--- a/synplan/mcts/policy/base.py
+++ b/synplan/mcts/policy/base.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import numpy as np
     import torch
 
     from synplan.chem.precursor import Precursor
@@ -55,7 +56,7 @@ class Policy(ABC):
         """
         raise NotImplementedError
 
-    def get_probs(self, precursor: "Precursor") -> "torch.Tensor | None":
+    def get_probs(self, precursor: "Precursor") -> "torch.Tensor | np.ndarray | None":
         """Return the per-rule probability tensor, or ``None`` on failure.
 
         :param precursor: The current precursor.
@@ -64,7 +65,7 @@ class Policy(ABC):
         """
         raise NotImplementedError
 
-    def get_logits(self, precursor: "Precursor") -> "torch.Tensor | None":
+    def get_logits(self, precursor: "Precursor") -> "torch.Tensor | np.ndarray | None":
         """Return the raw per-rule logits tensor, or ``None`` on failure.
 
         :param precursor: The current precursor.

--- a/synplan/mcts/policy/composite.py
+++ b/synplan/mcts/policy/composite.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING
 
-import torch
-
 from synplan.mcts.policy.base import Policy
 
 if TYPE_CHECKING:
+    import torch
+
     from synplan.chem.precursor import Precursor
     from synplan.chem.reaction import CanonicalRetroReactor
 
@@ -77,16 +77,22 @@ class CompositePolicy(Policy):
 
     def _get_combined_probs(self, precursor: Precursor) -> torch.Tensor | None:
         """Weighted-logit softmax merge of the two policies, or ``None``."""
+        import torch
+
         filtering_logits = self.filtering_policy.get_logits(precursor)
         ranking_logits = self.ranking_policy.get_logits(precursor)
         if filtering_logits is None or ranking_logits is None:
             return None
-        combined_logits = filtering_logits + self.ranking_weight * ranking_logits
+        combined_logits = torch.as_tensor(
+            filtering_logits
+        ) + self.ranking_weight * torch.as_tensor(ranking_logits)
         return torch.softmax(combined_logits / self.temperature, dim=-1)
 
     def _predict_rules_common(
         self, precursor: Precursor, n_rules: int
     ) -> tuple[list[float], list[int]] | None:
+        import torch
+
         self._validate_dimensions(n_rules)
         combined_probs = self._get_combined_probs(precursor)
         if combined_probs is None:

--- a/synplan/mcts/policy/onnx.py
+++ b/synplan/mcts/policy/onnx.py
@@ -1,0 +1,55 @@
+"""ONNX ranking inference with the existing template-policy selection behavior."""
+
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import numpy as np
+
+from synplan.mcts.policy.template_based import TemplateBasedPolicy
+from synplan.ml.featurization.molecules import mol_to_numpy
+
+
+class OnnxPolicy(TemplateBasedPolicy):
+    """Run an exported ranking model on CPU without Torch."""
+
+    def __init__(self, path, *, top_rules=50, rule_prob_threshold=0.0):
+        import onnxruntime as ort
+
+        options = ort.SessionOptions()
+        options.intra_op_num_threads = 1
+        self.session = ort.InferenceSession(
+            str(path), options, providers=["CPUExecutionProvider"]
+        )
+        metadata = self.session.get_modelmeta().custom_metadata_map
+        if metadata.get("synplan.policy") != "ranking-v1":
+            raise ValueError("Expected a SynPlanner ONNX ranking policy export")
+        self.input_names = {item.name for item in self.session.get_inputs()}
+        self.policy_net = SimpleNamespace(
+            n_rules=self.session.get_outputs()[0].shape[-1],
+            policy_type="ranking",
+            rule_vocabulary_digest=metadata.get("synplan.rule_vocabulary_digest"),
+        )
+        self.top_rules = top_rules
+        self.rule_prob_threshold = rule_prob_threshold
+        self.priority_rules_fraction = 0.5
+        self._proposal_cache = OrderedDict()
+
+    def _predict(self, precursor, output):
+        arrays = mol_to_numpy(precursor.policy_molecule, canonicalize=False)
+        if arrays is None:
+            return None
+        inputs = {name: arrays[name] for name in self.input_names}
+        values = self.session.run([output], inputs)[0]
+        return values[0].astype(np.float64)
+
+    def _select_rules(self, probs):
+        k = min(self.top_rules, probs.size)
+        ids = np.argpartition(-probs, k - 1)[:k]
+        ids = ids[np.argsort(-probs[ids])]
+        return probs[ids], ids
+
+    def get_probs(self, precursor):
+        return self._predict(precursor, "probabilities")
+
+    def get_logits(self, precursor):
+        return self._predict(precursor, "logits")

--- a/synplan/mcts/policy/onnx.py
+++ b/synplan/mcts/policy/onnx.py
@@ -1,4 +1,4 @@
-"""ONNX ranking inference with the existing template-policy selection behavior."""
+"""ONNX inference with the existing template-policy selection behavior."""
 
 from collections import OrderedDict
 from types import SimpleNamespace
@@ -10,7 +10,7 @@ from synplan.ml.featurization.molecules import mol_to_numpy
 
 
 class OnnxPolicy(TemplateBasedPolicy):
-    """Run an exported ranking model on CPU without Torch."""
+    """Run an exported ranking or filtering model on CPU without Torch."""
 
     def __init__(self, path, *, top_rules=50, rule_prob_threshold=0.0):
         import onnxruntime as ort
@@ -21,12 +21,17 @@ class OnnxPolicy(TemplateBasedPolicy):
             str(path), options, providers=["CPUExecutionProvider"]
         )
         metadata = self.session.get_modelmeta().custom_metadata_map
-        if metadata.get("synplan.policy") != "ranking-v1":
-            raise ValueError("Expected a SynPlanner ONNX ranking policy export")
+        policy_type = {"ranking-v1": "ranking", "filtering-v1": "filtering"}.get(
+            metadata.get("synplan.policy")
+        )
+        if policy_type is None:
+            raise ValueError(
+                "Expected a SynPlanner ONNX ranking or filtering policy export"
+            )
         self.input_names = {item.name for item in self.session.get_inputs()}
         self.policy_net = SimpleNamespace(
             n_rules=self.session.get_outputs()[0].shape[-1],
-            policy_type="ranking",
+            policy_type=policy_type,
             rule_vocabulary_digest=metadata.get("synplan.rule_vocabulary_digest"),
         )
         self.top_rules = top_rules
@@ -34,22 +39,41 @@ class OnnxPolicy(TemplateBasedPolicy):
         self.priority_rules_fraction = 0.5
         self._proposal_cache = OrderedDict()
 
-    def _predict(self, precursor, output):
+    def _predict(self, precursor, outputs):
         arrays = mol_to_numpy(precursor.policy_molecule, canonicalize=False)
         if arrays is None:
             return None
         inputs = {name: arrays[name] for name in self.input_names}
-        values = self.session.run([output], inputs)[0]
-        return values[0].astype(np.float64)
+        values = self.session.run(outputs, inputs)
+        return [value[0].astype(np.float64) for value in values]
 
     def _select_rules(self, probs):
         k = min(self.top_rules, probs.size)
         ids = np.argpartition(-probs, k - 1)[:k]
         ids = ids[np.argsort(-probs[ids])]
-        return probs[ids], ids
+        selected = probs[ids]
+        if self.policy_net.policy_type == "filtering":
+            selected = np.exp(selected - selected.max())
+            selected /= selected.sum()
+        return selected, ids
 
     def get_probs(self, precursor):
-        return self._predict(precursor, "probabilities")
+        filtering = self.policy_net.policy_type == "filtering"
+        outputs = ["probabilities", "priority"] if filtering else ["probabilities"]
+        values = self._predict(precursor, outputs)
+        if values is None:
+            return None
+        if filtering:
+            coef = self.priority_rules_fraction
+            return (1 - coef) * values[0] + coef * values[1]
+        return values[0]
 
     def get_logits(self, precursor):
-        return self._predict(precursor, "logits")
+        values = self._predict(precursor, ["logits"])
+        return values[0] if values is not None else None
+
+    def get_filtering_probs_only(self, precursor):
+        if self.policy_net.policy_type != "filtering":
+            raise ValueError("This method is only for filtering policy networks")
+        values = self._predict(precursor, ["probabilities"])
+        return values[0] if values is not None else None

--- a/synplan/mcts/policy/onnx.py
+++ b/synplan/mcts/policy/onnx.py
@@ -12,7 +12,14 @@ from synplan.ml.featurization.molecules import mol_to_numpy
 class OnnxPolicy(TemplateBasedPolicy):
     """Run an exported ranking or filtering model on CPU without Torch."""
 
-    def __init__(self, path, *, top_rules=50, rule_prob_threshold=0.0):
+    def __init__(
+        self,
+        path,
+        *,
+        top_rules=50,
+        rule_prob_threshold=0.0,
+        priority_rules_fraction=0.5,
+    ):
         import onnxruntime as ort
 
         options = ort.SessionOptions()
@@ -36,7 +43,7 @@ class OnnxPolicy(TemplateBasedPolicy):
         )
         self.top_rules = top_rules
         self.rule_prob_threshold = rule_prob_threshold
-        self.priority_rules_fraction = 0.5
+        self.priority_rules_fraction = priority_rules_fraction
         self._proposal_cache = OrderedDict()
 
     def _predict(self, precursor, outputs):

--- a/synplan/mcts/policy/template_based.py
+++ b/synplan/mcts/policy/template_based.py
@@ -7,19 +7,16 @@ from collections import OrderedDict
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING
 
-import torch
-
 from synplan.chem.reaction.rules import rule_query_pattern
 from synplan.chem.reaction.rules.representation import (
     rule_representation_digest,
     rule_smarts_from_reactors,
 )
 from synplan.mcts.policy.base import Policy
-from synplan.ml.featurization.fingerprints import rule_fingerprints_from_smarts
-from synplan.ml.featurization.molecules import mol_to_pyg
-from synplan.ml.featurization.rules import query_cgr_graphs_from_smarts
 
 if TYPE_CHECKING:
+    import numpy as np
+    import torch
     import torch_geometric.data
 
     from synplan.chem.precursor import Precursor
@@ -76,19 +73,30 @@ class TemplateBasedPolicy(Policy):
 
     def _get_graph(self, precursor: Precursor) -> torch_geometric.data.Data | None:
         """Convert a precursor molecule to a PyG graph."""
+        from synplan.ml.featurization.molecules import mol_to_pyg
+
         return mol_to_pyg(precursor.policy_molecule, canonicalize=False)
 
+    def _select_rules(self, probs):
+        import torch
+
+        k = min(self.top_rules, probs.numel())
+        sorted_probs, sorted_rules = torch.topk(probs, k=k, sorted=True)
+        if getattr(self.policy_net, "policy_type", "ranking") == "filtering":
+            sorted_probs = torch.softmax(sorted_probs, -1)
+        return sorted_probs, sorted_rules
+
     @abstractmethod
-    def get_logits(self, precursor: Precursor) -> torch.Tensor | None:
+    def get_logits(self, precursor: Precursor) -> torch.Tensor | np.ndarray | None:
         """Return raw per-rule logits, or ``None`` if featurization fails."""
 
     @abstractmethod
-    def get_probs(self, precursor: Precursor) -> torch.Tensor | None:
+    def get_probs(self, precursor: Precursor) -> torch.Tensor | np.ndarray | None:
         """Return per-rule probabilities, or ``None`` if featurization fails."""
 
     def _predict_rules_common(
         self, precursor: Precursor, n_rules: int
-    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[np.ndarray, np.ndarray] | None:
         """Top-k probabilities and rule ids for a precursor, or ``None``."""
         out_dim = self.n_rules
         if out_dim != n_rules:
@@ -119,11 +127,7 @@ class TemplateBasedPolicy(Policy):
         probs = self.get_probs(precursor)
         if probs is None:
             return None
-        k = min(self.top_rules, probs.numel())
-        sorted_probs, sorted_rules = torch.topk(probs, k=k, sorted=True)
-        if getattr(self.policy_net, "policy_type", "ranking") == "filtering":
-            sorted_probs = torch.softmax(sorted_probs, -1)
-        result = sorted_probs, sorted_rules
+        result = self._select_rules(probs)
         self._proposal_cache[key] = result
         if len(self._proposal_cache) > 256:
             self._proposal_cache.popitem(last=False)
@@ -178,6 +182,8 @@ class LinearPolicy(TemplateBasedPolicy):
 
     def get_logits(self, precursor: Precursor) -> torch.Tensor | None:
         """Return raw per-rule logits (before sigmoid/softmax)."""
+        import torch
+
         pyg_graph = self._get_graph(precursor)
         if not pyg_graph:
             return None
@@ -187,6 +193,8 @@ class LinearPolicy(TemplateBasedPolicy):
 
     def get_probs(self, precursor: Precursor) -> torch.Tensor | None:
         """Return per-rule probabilities, mixing priority for filtering nets."""
+        import torch
+
         pyg_graph = self._get_graph(precursor)
         if not pyg_graph:
             return None
@@ -201,6 +209,8 @@ class LinearPolicy(TemplateBasedPolicy):
 
     def get_filtering_probs_only(self, precursor: Precursor) -> torch.Tensor | None:
         """Return the filtering rule head (sigmoid) without priority mixing."""
+        import torch
+
         if self.policy_net.policy_type != "filtering":
             raise ValueError("This method is only for filtering policy networks")
         logits = self.get_logits(precursor)
@@ -233,6 +243,11 @@ class MHNReactPolicy(TemplateBasedPolicy):
         self, reaction_rules: Sequence[CanonicalRetroReactor]
     ) -> None:
         """Encode a runtime rule set once for MHN ranking prediction."""
+        import torch
+
+        from synplan.ml.featurization.fingerprints import rule_fingerprints_from_smarts
+        from synplan.ml.featurization.rules import query_cgr_graphs_from_smarts
+
         if (
             self._rule_associations is not None
             and self._bound_reaction_rules is reaction_rules
@@ -276,6 +291,8 @@ class MHNReactPolicy(TemplateBasedPolicy):
 
     def get_logits(self, precursor: Precursor) -> torch.Tensor | None:
         """Return MHN logits for the currently prepared rule associations."""
+        import torch
+
         pyg_graph = self._get_graph(precursor)
         if not pyg_graph:
             return None
@@ -290,6 +307,8 @@ class MHNReactPolicy(TemplateBasedPolicy):
 
     def get_probs(self, precursor: Precursor) -> torch.Tensor | None:
         """Return MHN ranking probabilities for prepared runtime rules."""
+        import torch
+
         logits = self.get_logits(precursor)
         return torch.softmax(logits, dim=-1) if logits is not None else None
 

--- a/synplan/mcts/tree.py
+++ b/synplan/mcts/tree.py
@@ -216,6 +216,8 @@ class Tree:
             )
             self._building_block_bucket_count: int | None = len(building_blocks)
         else:
+            # ponytail: CLI stock is already normalized, but direct Tree callers need
+            # this. Reusing prepared stock would avoid reparsing it for every target.
             self.building_blocks = (
                 frozenset(str(smiles(s, ignore_stereo=True)) for s in building_blocks)
                 if config.stereo_mode == "off"
@@ -274,6 +276,7 @@ class Tree:
                 )
 
         if rollout is not None:
+            # Rollouts must use the same normalized stock, rules and stereo mode as the tree.
             rollout.building_blocks = self.building_blocks
             rollout.reaction_rules = self.reaction_rules
             rollout.match_stereo = config.stereo_mode != "off"

--- a/synplan/ml/featurization/__init__.py
+++ b/synplan/ml/featurization/__init__.py
@@ -1,21 +1,27 @@
-"""Torch featurization layer turning chython rules and molecules into tensors and PyG ``Data``."""
+"""Molecular NumPy features and optional Torch/PyG featurization."""
 
 from synplan.ml.featurization.molecules import (
     MENDEL_INFO,
+    atom_features,
     atom_to_vector,
+    bond_features,
     bonds_to_vector,
     mol_to_matrix,
     mol_to_numpy,
     mol_to_pyg,
+    molecule_features,
 )
 
 __all__ = [
     "MENDEL_INFO",
+    "atom_features",
     "atom_to_vector",
+    "bond_features",
     "bonds_to_vector",
     "mol_to_matrix",
     "mol_to_numpy",
     "mol_to_pyg",
+    "molecule_features",
     "query_cgr_graph_from_rule_query",
     "query_cgr_graphs_from_smarts",
     "query_cgr_to_pyg",

--- a/synplan/ml/featurization/__init__.py
+++ b/synplan/ml/featurization/__init__.py
@@ -1,17 +1,12 @@
 """Torch featurization layer turning chython rules and molecules into tensors and PyG ``Data``."""
 
-from synplan.ml.featurization.fingerprints import rule_fingerprints_from_smarts
 from synplan.ml.featurization.molecules import (
     MENDEL_INFO,
     atom_to_vector,
     bonds_to_vector,
     mol_to_matrix,
+    mol_to_numpy,
     mol_to_pyg,
-)
-from synplan.ml.featurization.rules import (
-    query_cgr_graph_from_rule_query,
-    query_cgr_graphs_from_smarts,
-    query_cgr_to_pyg,
 )
 
 __all__ = [
@@ -19,9 +14,26 @@ __all__ = [
     "atom_to_vector",
     "bonds_to_vector",
     "mol_to_matrix",
+    "mol_to_numpy",
     "mol_to_pyg",
     "query_cgr_graph_from_rule_query",
     "query_cgr_graphs_from_smarts",
     "query_cgr_to_pyg",
     "rule_fingerprints_from_smarts",
 ]
+
+
+def __getattr__(name):
+    if name == "rule_fingerprints_from_smarts":
+        from . import fingerprints
+
+        return getattr(fingerprints, name)
+    if name in {
+        "query_cgr_graph_from_rule_query",
+        "query_cgr_graphs_from_smarts",
+        "query_cgr_to_pyg",
+    }:
+        from . import rules
+
+        return getattr(rules, name)
+    raise AttributeError(name)

--- a/synplan/ml/featurization/molecules.py
+++ b/synplan/ml/featurization/molecules.py
@@ -1,15 +1,16 @@
-"""Torch tensorization of chython molecules into PyG graphs."""
+"""Shared molecular features for NumPy inference and Torch training."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import torch
+import numpy as np
 from chython.containers import MoleculeContainer
 from chython.exceptions import InvalidAromaticRing
-from torch import Tensor
-from torch_geometric.data.data import Data
-from torch_geometric.transforms import ToUndirected
+
+if TYPE_CHECKING:
+    from torch import Tensor
+    from torch_geometric.data import Data
 
 
 def atom_to_vector(atom: Any) -> Tensor:
@@ -29,7 +30,13 @@ def atom_to_vector(atom: Any) -> Tensor:
 
     :return: The vector of the atom.
     """
-    vector = torch.zeros(8, dtype=torch.uint8)
+    import torch
+
+    return torch.tensor(_atom_features(atom), dtype=torch.uint8)
+
+
+def _atom_features(atom):
+    vector = [0] * 8
     period, group, shell, electrons = MENDEL_INFO[atom.atomic_symbol]
     vector[0] = atom.atomic_number
     vector[1] = period
@@ -53,36 +60,58 @@ def bonds_to_vector(molecule: MoleculeContainer, atom_ind: int) -> Tensor:
         bonds connected to the atom with the given index in the molecule.
     """
 
-    vector = torch.zeros(3, dtype=torch.uint8)
+    import torch
+
+    return torch.tensor(_bond_features(molecule, atom_ind), dtype=torch.uint8)
+
+
+def _bond_features(molecule, atom_ind):
+    vector = [0] * 3
     for _, b_order in molecule.bond_items(atom_ind):
         vector[int(b_order) - 1] += 1
     return vector
 
 
 def mol_to_matrix(molecule: MoleculeContainer) -> Tensor:
-    """Given a molecule, it returns a vector of shape (max_atoms, 12) where each row is
+    """Given a molecule, it returns a vector of shape (max_atoms, 11) where each row is
     an atom and each column is a feature.
 
     :param molecule: The molecule to be converted to a vector
     :return: The atoms vectors array.
     """
 
-    atoms_vectors = torch.zeros((len(molecule), 11), dtype=torch.uint8)
+    import torch
+
+    return torch.from_numpy(_mol_matrix(molecule))
+
+
+def _mol_matrix(molecule):
+    atoms_vectors = np.zeros((len(molecule), 11), dtype=np.uint8)
     for n, atom in molecule.atoms():
-        atoms_vectors[n - 1][:8] = atom_to_vector(atom)
+        atoms_vectors[n - 1][:8] = _atom_features(atom)
     for n, _ in molecule.atoms():
-        atoms_vectors[n - 1][8:] = bonds_to_vector(molecule, n)
+        atoms_vectors[n - 1][8:] = _bond_features(molecule, n)
 
     return atoms_vectors
 
 
 def mol_to_pyg(molecule: MoleculeContainer, canonicalize: bool = True) -> Data | None:
-    """Takes a list of molecules and returns a list of PyTorch Geometric graphs, a one-
-    hot encoded vectors of the atoms, and a matrices of the bonds.
+    """Wrap the shared molecular features as a PyG graph for Torch models."""
+    import torch
+    from torch_geometric.data import Data
 
-    :param molecule: The molecule to be converted to PyTorch Geometric graph.
+    arrays = mol_to_numpy(molecule, canonicalize=canonicalize)
+    if arrays is None:
+        return None
+    return Data(**{key: torch.from_numpy(value) for key, value in arrays.items()})
+
+
+def mol_to_numpy(molecule: MoleculeContainer, canonicalize: bool = True) -> dict | None:
+    """Return atom features, directed edges and bond features as NumPy arrays.
+
+    :param molecule: The molecule to featurize.
     :param canonicalize: If True, the input molecule is canonicalized.
-    :return: The list of PyGraph objects.
+    :return: Input arrays, or None for an unsupported molecular graph.
     """
 
     if len(molecule) == 1:  # to avoid a precursor to be a single atom
@@ -109,34 +138,25 @@ def mol_to_pyg(molecule: MoleculeContainer, canonicalize: bool = True) -> Data |
     edge_index = []
     edge_attr = []
     for atom, neighbour, bond in tmp_molecule.bonds():
-        edge_index.append([atom - 1, neighbour - 1])
-        edge_attr.append(
-            [
-                float(bond.order == 1),
-                float(bond.order == 2),
-                float(bond.order == 3),
-                float(bond.in_ring),
-            ]
-        )
+        edge_index.extend([[atom - 1, neighbour - 1], [neighbour - 1, atom - 1]])
+        features = [
+            float(bond.order == 1),
+            float(bond.order == 2),
+            float(bond.order == 3),
+            float(bond.in_ring),
+        ]
+        edge_attr.extend([features, features])
     # Edgeless precursors (e.g. [NH4+].[OH-]) have no bonded fragment to expand;
     # disconnected salts still pass as long as one component has bonds.
     if not edge_index:
         return None
-    edge_index = torch.tensor(edge_index, dtype=torch.long)
-    edge_attr = torch.tensor(edge_attr, dtype=torch.float)
-
-    x = mol_to_matrix(tmp_molecule)
-
-    mol_pyg_graph = Data(
-        x=x,
-        edge_index=edge_index.t().contiguous(),
-        edge_attr=edge_attr,
-    )
-    mol_pyg_graph = ToUndirected()(mol_pyg_graph)
-
-    assert mol_pyg_graph.is_undirected()
-
-    return mol_pyg_graph
+    edge_index = np.asarray(edge_index, dtype=np.int64)
+    order = np.lexsort((edge_index[:, 1], edge_index[:, 0]))
+    return {
+        "x": _mol_matrix(tmp_molecule),
+        "edge_index": np.ascontiguousarray(edge_index[order].T),
+        "edge_attr": np.asarray(edge_attr, dtype=np.float32)[order],
+    }
 
 
 MENDEL_INFO = {
@@ -199,5 +219,6 @@ __all__ = [
     "atom_to_vector",
     "bonds_to_vector",
     "mol_to_matrix",
+    "mol_to_numpy",
     "mol_to_pyg",
 ]

--- a/synplan/ml/featurization/molecules.py
+++ b/synplan/ml/featurization/molecules.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 from chython.containers import MoleculeContainer
@@ -13,30 +13,9 @@ if TYPE_CHECKING:
     from torch_geometric.data import Data
 
 
-def atom_to_vector(atom: Any) -> Tensor:
-    """Given an atom, return a vector of length 8 with the following
-    information:
-
-    1. Atomic number
-    2. Period
-    3. Group
-    4. Number of electrons + atom's charge
-    5. Shell
-    6. Total number of hydrogens
-    7. Whether the atom is in a ring
-    8. Number of neighbors
-
-    :param atom: The atom object.
-
-    :return: The vector of the atom.
-    """
-    import torch
-
-    return torch.tensor(_atom_features(atom), dtype=torch.uint8)
-
-
-def _atom_features(atom):
-    vector = [0] * 8
+def atom_features(atom) -> np.ndarray:
+    """Return the eight atomic descriptors shared by inference and training."""
+    vector = np.zeros(8, dtype=np.uint8)
     period, group, shell, electrons = MENDEL_INFO[atom.atomic_symbol]
     vector[0] = atom.atomic_number
     vector[1] = period
@@ -49,27 +28,36 @@ def _atom_features(atom):
     return vector
 
 
-def bonds_to_vector(molecule: MoleculeContainer, atom_ind: int) -> Tensor:
-    """Takes a molecule and an atom index as input, and returns a vector representing
-    the bond orders of the atom's bonds.
-
-    :param molecule: The given molecule.
-    :param atom_ind: The index of the atom in the molecule to be converted to the bond
-        vector.
-    :return: The torch tensor of size 3, with each element representing the order of
-        bonds connected to the atom with the given index in the molecule.
-    """
-
-    import torch
-
-    return torch.tensor(_bond_features(molecule, atom_ind), dtype=torch.uint8)
-
-
-def _bond_features(molecule, atom_ind):
-    vector = [0] * 3
+def bond_features(molecule: MoleculeContainer, atom_ind: int) -> np.ndarray:
+    """Count single, double and triple bonds adjacent to an atom."""
+    vector = np.zeros(3, dtype=np.uint8)
     for _, b_order in molecule.bond_items(atom_ind):
         vector[int(b_order) - 1] += 1
     return vector
+
+
+def molecule_features(molecule: MoleculeContainer) -> np.ndarray:
+    """Return the 11 features per atom for a molecule numbered from one."""
+    atoms_vectors = np.zeros((len(molecule), 11), dtype=np.uint8)
+    for n, atom in molecule.atoms():
+        atoms_vectors[n - 1][:8] = atom_features(atom)
+        atoms_vectors[n - 1][8:] = bond_features(molecule, n)
+
+    return atoms_vectors
+
+
+def atom_to_vector(atom) -> Tensor:
+    """Return atomic descriptors as a Torch tensor (legacy public API)."""
+    import torch
+
+    return torch.from_numpy(atom_features(atom))
+
+
+def bonds_to_vector(molecule: MoleculeContainer, atom_ind: int) -> Tensor:
+    """Return bond counts as a Torch tensor (legacy public API)."""
+    import torch
+
+    return torch.from_numpy(bond_features(molecule, atom_ind))
 
 
 def mol_to_matrix(molecule: MoleculeContainer) -> Tensor:
@@ -82,17 +70,7 @@ def mol_to_matrix(molecule: MoleculeContainer) -> Tensor:
 
     import torch
 
-    return torch.from_numpy(_mol_matrix(molecule))
-
-
-def _mol_matrix(molecule):
-    atoms_vectors = np.zeros((len(molecule), 11), dtype=np.uint8)
-    for n, atom in molecule.atoms():
-        atoms_vectors[n - 1][:8] = _atom_features(atom)
-    for n, _ in molecule.atoms():
-        atoms_vectors[n - 1][8:] = _bond_features(molecule, n)
-
-    return atoms_vectors
+    return torch.from_numpy(molecule_features(molecule))
 
 
 def mol_to_pyg(molecule: MoleculeContainer, canonicalize: bool = True) -> Data | None:
@@ -153,7 +131,7 @@ def mol_to_numpy(molecule: MoleculeContainer, canonicalize: bool = True) -> dict
     edge_index = np.asarray(edge_index, dtype=np.int64)
     order = np.lexsort((edge_index[:, 1], edge_index[:, 0]))
     return {
-        "x": _mol_matrix(tmp_molecule),
+        "x": molecule_features(tmp_molecule),
         "edge_index": np.ascontiguousarray(edge_index[order].T),
         "edge_attr": np.asarray(edge_attr, dtype=np.float32)[order],
     }
@@ -216,9 +194,12 @@ MENDEL_INFO = {
 
 __all__ = [
     "MENDEL_INFO",
+    "atom_features",
     "atom_to_vector",
+    "bond_features",
     "bonds_to_vector",
     "mol_to_matrix",
     "mol_to_numpy",
     "mol_to_pyg",
+    "molecule_features",
 ]

--- a/synplan/ml/training/supervised.py
+++ b/synplan/ml/training/supervised.py
@@ -257,7 +257,7 @@ def create_training_logger(logger_config: dict | None, results_path: Path):
         except ImportError as e:
             raise ImportError(
                 "MLflow logger requires the 'mlflow' package. "
-                "Install SynPlanner with the 'mlflow' or 'loggers' extra."
+                "Install it with pip install mlflow."
             ) from e
         return MLFlowLogger(**kwargs)
     elif logger_type == "wandb":
@@ -266,7 +266,7 @@ def create_training_logger(logger_config: dict | None, results_path: Path):
         except ImportError as e:
             raise ImportError(
                 "Wandb logger requires the 'wandb' package. "
-                "Install SynPlanner with the 'wandb' or 'loggers' extra."
+                "Install it with pip install wandb."
             ) from e
         return WandbLogger(**kwargs)
     else:

--- a/synplan/utils/frames.py
+++ b/synplan/utils/frames.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from html import escape
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def depict_value(value: Any) -> str:
@@ -47,6 +48,8 @@ class ChemFrame:
         data: pd.DataFrame | Iterable[Mapping[str, Any]],
         depict_columns: Iterable[str] | None = None,
     ) -> None:
+        import pandas as pd
+
         self._df = data if isinstance(data, pd.DataFrame) else pd.DataFrame(list(data))
         if depict_columns is not None:
             self.depict_columns = tuple(depict_columns)
@@ -93,6 +96,8 @@ class ChemFrame:
         return repr(self._df)
 
     def _rewrap(self, value: Any) -> Any:
+        import pandas as pd
+
         if isinstance(value, pd.DataFrame):
             return type(self)(value, self.depict_columns)
         return value
@@ -107,6 +112,8 @@ def tree_stats_frame(trees: Any) -> pd.DataFrame:
     :param trees: One tree, an iterable of trees, or an ordered ``run name -> tree`` mapping.
     :return: A frame indexed by run name — the mapping keys, or positions otherwise.
     """
+    import pandas as pd
+
     if hasattr(trees, "to_stats_dict"):
         trees = [trees]
     items = (

--- a/synplan/utils/loading.py
+++ b/synplan/utils/loading.py
@@ -478,7 +478,7 @@ def build_policy_from_config(
     except ModuleNotFoundError as error:
         if error.name in {"torch", "torch_geometric"}:
             raise ImportError(
-                "Checkpoint inference requires SynPlanner[torch]; use .onnx weights for the base install"
+                "Checkpoint inference requires SynPlanner[cpu] (or a CUDA extra); use .onnx weights for the base install"
             ) from error
         raise
 

--- a/synplan/utils/loading.py
+++ b/synplan/utils/loading.py
@@ -459,17 +459,20 @@ def load_value_net(
 def build_policy_from_config(
     policy_config: "PolicyNetworkConfig",
 ) -> "TemplateBasedPolicy":
-    """Build a template policy from a Torch checkpoint or ONNX ranking export."""
+    """Build a template policy from a Torch checkpoint or ONNX policy export."""
     if Path(policy_config.weights_path).suffix == ".onnx":
         from synplan.mcts.policy.onnx import OnnxPolicy
 
-        if policy_config.policy_type != "ranking":
-            raise ValueError("ONNX policies currently support ranking only")
-        return OnnxPolicy(
+        policy = OnnxPolicy(
             policy_config.weights_path,
             top_rules=policy_config.top_rules,
             rule_prob_threshold=policy_config.rule_prob_threshold,
         )
+        if policy.policy_net.policy_type != policy_config.policy_type:
+            raise ValueError(
+                "ONNX policy type does not match the configured policy_type"
+            )
+        return policy
 
     from synplan.mcts.policy import LinearPolicy, MHNReactPolicy
 

--- a/synplan/utils/loading.py
+++ b/synplan/utils/loading.py
@@ -454,9 +454,28 @@ def load_value_net(
 def build_policy_from_config(
     policy_config: "PolicyNetworkConfig",
 ) -> "TemplateBasedPolicy":
-    """Build a :class:`TemplateBasedPolicy` matching a checkpoint architecture."""
+    """Build a template policy from a Torch checkpoint or ONNX ranking export."""
+    if Path(policy_config.weights_path).suffix == ".onnx":
+        from synplan.mcts.policy.onnx import OnnxPolicy
+
+        if policy_config.policy_type != "ranking":
+            raise ValueError("ONNX policies currently support ranking only")
+        return OnnxPolicy(
+            policy_config.weights_path,
+            top_rules=policy_config.top_rules,
+            rule_prob_threshold=policy_config.rule_prob_threshold,
+        )
+
     from synplan.mcts.policy import LinearPolicy, MHNReactPolicy
-    from synplan.ml.networks.checkpoint import load_policy_network_from_checkpoint
+
+    try:
+        from synplan.ml.networks.checkpoint import load_policy_network_from_checkpoint
+    except ModuleNotFoundError as error:
+        if error.name in {"torch", "torch_geometric"}:
+            raise ImportError(
+                "Checkpoint inference requires SynPlanner[torch]; use .onnx weights for the base install"
+            ) from error
+        raise
 
     policy_net = load_policy_network_from_checkpoint(
         policy_config.weights_path, batch_size=1, dropout=0

--- a/synplan/utils/loading.py
+++ b/synplan/utils/loading.py
@@ -467,6 +467,7 @@ def build_policy_from_config(
             policy_config.weights_path,
             top_rules=policy_config.top_rules,
             rule_prob_threshold=policy_config.rule_prob_threshold,
+            priority_rules_fraction=policy_config.priority_rules_fraction,
         )
         if policy.policy_net.policy_type != policy_config.policy_type:
             raise ValueError(

--- a/synplan/utils/loading.py
+++ b/synplan/utils/loading.py
@@ -15,7 +15,7 @@ from chython import smarts as smarts_parser
 from chython.containers import ReactionContainer
 from chython.files.daylight.tokenize import smarts_tokenize
 from chython.reactor.reactor import Reactor
-from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub import file_exists, hf_hub_download, snapshot_download
 
 from synplan.chem.building_blocks.io import load_building_blocks as load_building_blocks
 from synplan.chem.reaction import CanonicalRetroReactor
@@ -146,7 +146,8 @@ def download_preset(
 
     The preset YAML lists explicit file paths under a ``files:`` key.
     Each file is downloaded into the ``save_to`` directory, preserving
-    the repository folder structure.
+    the repository folder structure. For ``.ckpt`` entries, a same-name
+    ``.onnx`` file in the same remote folder is preferred when available.
 
     :param preset_name: Name of the preset (e.g. ``"synplanner-gps-mcule-molport"``).
     :param save_to: Local directory to save downloaded files.
@@ -173,6 +174,10 @@ def download_preset(
     result: dict[str, Path] = {}
     for key, repo_path in preset.get("files", {}).items():
         parts = PurePosixPath(repo_path)
+        if parts.suffix == ".ckpt" and file_exists(
+            repo_id=repo, filename=str(parts.with_suffix(".onnx"))
+        ):
+            parts = parts.with_suffix(".onnx")
         local_path = Path(
             hf_hub_download(
                 repo_id=repo,

--- a/synplan/utils/logging.py
+++ b/synplan/utils/logging.py
@@ -8,8 +8,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from IPython import get_ipython
-
 # --------------------------------------------------------------------------- #
 #                               Helper classes                                #
 # --------------------------------------------------------------------------- #
@@ -43,6 +41,11 @@ class HiddenPrints:
 
 
 def _in_notebook() -> bool:
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+
     ip = get_ipython()
     return bool(ip) and ip.__class__.__name__ == "ZMQInteractiveShell"
 

--- a/synplan/utils/routedraw.py
+++ b/synplan/utils/routedraw.py
@@ -284,12 +284,12 @@ def _to_svg(
             label, payload = offer
             # 6.4px per character at 11px semibold, plus the chip's own padding.
             pill = 24.0 + 6.4 * len(label)
-            top = node.y + node.h + PILL_GAP
+            pill_y = node.y + node.h + PILL_GAP
             parts.append(
                 f'<g class="sp-price" data-offers="{escape(payload, quote=True)}">'
-                f'<rect x="{node.x:.1f}" y="{top:.1f}" '
+                f'<rect x="{node.x:.1f}" y="{pill_y:.1f}" '
                 f'width="{pill:.1f}" height="{PILL_H}" rx="{PILL_H / 2}"/>'
-                f'<text x="{node.x + 12:.1f}" y="{top + PILL_H / 2:.1f}">'
+                f'<text x="{node.x + 12:.1f}" y="{pill_y + PILL_H / 2:.1f}">'
                 f"{escape(label)}</text></g>"
             )
 

--- a/synplan/utils/visualisation/clustering.py
+++ b/synplan/utils/visualisation/clustering.py
@@ -394,31 +394,21 @@ def lg_table_2_html(subcluster, routes_to_display=None, if_display=True):
         html += f"<th style='border: 1px solid black; padding: 4px;'>{mark}</th>"
     html += "</tr>"
 
-    # Fill in the rows
-    if len(routes_to_display) == 0:
-        for route_id, route_data in subcluster["routes_data"].items():
-            html += f"<tr><td style='border: 1px solid black; padding: 4px;'>{route_id}</td>"
-            for mark in all_marks:
-                html += "<td style='border: 1px solid black; padding: 4px;'>"
-                if mark in route_data:
-                    html += depict_value(route_data[mark])
-                html += "</td>"
-            html += "</tr>"
-    else:
-        for route_id in routes_to_display:
-            # Check if the route_id exists in the subcluster data
-            if route_id in subcluster["routes_data"]:
-                route_data = subcluster["routes_data"][route_id]
-                html += f"<tr><td style='border: 1px solid black; padding: 4px;'>{route_id}</td>"
-                for mark in all_marks:
-                    html += "<td style='border: 1px solid black; padding: 4px;'>"
-                    if mark in route_data:
-                        html += depict_value(route_data[mark])
-                    html += "</td>"
-                html += "</tr>"
-            else:
-                # Optionally, you can note that the route_id was not found
-                html += f"<tr><td colspan='{len(all_marks) + 1}' style='border: 1px solid black; padding: 4px; color:red;'>Route ID {route_id} not found.</td></tr>"
+    # Fill in the rows, preserving explicit route order and missing-ID messages.
+    for route_id in routes_to_display or subcluster["routes_data"]:
+        if route_id not in subcluster["routes_data"]:
+            html += f"<tr><td colspan='{len(all_marks) + 1}' style='border: 1px solid black; padding: 4px; color:red;'>Route ID {route_id} not found.</td></tr>"
+            continue
+        route_data = subcluster["routes_data"][route_id]
+        html += (
+            f"<tr><td style='border: 1px solid black; padding: 4px;'>{route_id}</td>"
+        )
+        for mark in all_marks:
+            html += "<td style='border: 1px solid black; padding: 4px;'>"
+            if mark in route_data:
+                html += depict_value(route_data[mark])
+            html += "</td>"
+        html += "</tr>"
 
     html += "</table>"
 

--- a/synplan/utils/visualisation/clustering.py
+++ b/synplan/utils/visualisation/clustering.py
@@ -6,8 +6,6 @@ import base64
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from IPython.display import HTML, display
-
 from synplan.chem.reaction.routes.io import make_dict
 from synplan.chem.reaction.routes.representation.depiction import (
     _temporary_render_config,
@@ -425,6 +423,8 @@ def lg_table_2_html(subcluster, routes_to_display=None, if_display=True):
     html += "</table>"
 
     if if_display:
+        from IPython.display import HTML, display
+
         display(HTML(html))
 
     return html
@@ -468,6 +468,8 @@ def supporting_table_2_html(subcluster, routes_to_display=None, if_display=True)
     html += "</table>"
 
     if if_display:
+        from IPython.display import HTML, display
+
         display(HTML(html))
 
     return html
@@ -560,6 +562,8 @@ def group_lg_table_2_html_fixed(
     html.append("</tbody></table>")
     out = "".join(html)
     if if_display:
+        from IPython.display import HTML, display
+
         display(HTML(out))
 
     return out

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 import synplan.interfaces.cli as cli
+import synplan.ml.training.supervised as supervised
 
 
 def test_synplan_help():
@@ -91,8 +92,8 @@ def test_ranking_policy_training_cli_accepts_litlogger(monkeypatch):
         observed["config"] = config
         observed["results_path"] = results_path
 
-    monkeypatch.setattr(cli, "create_policy_dataset", fake_create_policy_dataset)
-    monkeypatch.setattr(cli, "run_policy_training", fake_run_policy_training)
+    monkeypatch.setattr(supervised, "create_policy_dataset", fake_create_policy_dataset)
+    monkeypatch.setattr(supervised, "run_policy_training", fake_run_policy_training)
 
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -130,14 +131,14 @@ def test_ranking_policy_training_cli_accepts_litlogger(monkeypatch):
 def test_mhn_ranking_policy_training_cli_uses_policy_data_only(monkeypatch):
     observed = {}
 
-    monkeypatch.setattr(cli, "create_policy_dataset", lambda **_kwargs: object())
+    monkeypatch.setattr(supervised, "create_policy_dataset", lambda **_kwargs: object())
 
     def fake_run_policy_training(datamodule, *, config, results_path):
         observed["datamodule"] = datamodule
         observed["config"] = config
         observed["results_path"] = results_path
 
-    monkeypatch.setattr(cli, "run_policy_training", fake_run_policy_training)
+    monkeypatch.setattr(supervised, "run_policy_training", fake_run_policy_training)
 
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -167,7 +168,9 @@ def test_mhn_network_tuning_cli_passes_checkpoint_and_new_policy_data(monkeypatc
     def fake_run_mhn_network_tuning(**kwargs):
         observed.update(kwargs)
 
-    monkeypatch.setattr(cli, "run_mhn_network_tuning", fake_run_mhn_network_tuning)
+    monkeypatch.setattr(
+        supervised, "run_mhn_network_tuning", fake_run_mhn_network_tuning
+    )
 
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/integration/test_cli_shipped_configs.py
+++ b/tests/integration/test_cli_shipped_configs.py
@@ -22,12 +22,12 @@ CONFIGS = Path(__file__).resolve().parents[2] / "configs"
 WORKERS = (
     "standardize_reactions_from_file",
     "filter_reactions_from_file",
-    "map_reactions_from_file",
+    "synplan.chem.reaction.curation.mapping.map_reactions_from_file",
     "extract_rules_from_reactions",
-    "create_policy_dataset",
-    "run_policy_training",
-    "run_mhn_network_tuning",
-    "run_updating",
+    "synplan.ml.training.supervised.create_policy_dataset",
+    "synplan.ml.training.supervised.run_policy_training",
+    "synplan.ml.training.supervised.run_mhn_network_tuning",
+    "synplan.ml.training.reinforcement.run_updating",
     "run_search",
     "load_policy_function",
     "load_reaction_rules",
@@ -184,7 +184,8 @@ def stubbed_workers(monkeypatch):
     """Replace every worker with a recorder, so only CLI wiring runs."""
     calls: list[str] = []
     for name in WORKERS:
-        monkeypatch.setattr(cli, name, lambda *a, _n=name, **kw: calls.append(_n))
+        path = name if "." in name else f"synplan.interfaces.cli.{name}"
+        monkeypatch.setattr(path, lambda *a, _n=name, **kw: calls.append(_n))
     return calls
 
 

--- a/tests/unit/mcts/test_algorithm.py
+++ b/tests/unit/mcts/test_algorithm.py
@@ -305,3 +305,21 @@ def test_select_nmcs_path_greedy_policy_and_random_on_real_tree():
     assert len(seq_r) == 1
     assert seq_r[0] in list(tree.children[1])
     assert last_rnd in list(tree.children[1])
+
+
+def test_extract_routes_preserves_unsolved_target():
+    from synplan.utils.visualisation import extract_routes
+
+    tree = build_tree("breadth_first", [])
+    tree.run()
+    assert not tree.winning_nodes
+    expected = [
+        {
+            "type": "mol",
+            "smiles": str(tree.nodes[1].curr_precursor.molecule),
+            "in_stock": False,
+            "children": [],
+        }
+    ]
+    assert extract_routes(tree) == expected
+    assert extract_routes(tree, extended=True, min_mol_size=100) == expected

--- a/tests/unit/mcts/test_mhn_ranking_expansion.py
+++ b/tests/unit/mcts/test_mhn_ranking_expansion.py
@@ -22,6 +22,8 @@ from synplan.mcts.policy.template_based import (
     LinearPolicy,
     MHNReactPolicy,
 )
+from synplan.ml.featurization import fingerprints
+from synplan.ml.featurization import rules as rule_features
 
 
 class _Rule:
@@ -110,7 +112,7 @@ def test_mhn_preparation_caches_encoded_rules(monkeypatch):
 
     monkeypatch.setattr(template_based, "rule_smarts_from_reactors", fake_rule_smarts)
     monkeypatch.setattr(
-        template_based, "rule_fingerprints_from_smarts", fake_rule_fingerprints
+        fingerprints, "rule_fingerprints_from_smarts", fake_rule_fingerprints
     )
     wrapper = _mhn_wrapper(_MHNPolicy())
     rules = [_Rule("A"), _Rule("B")]
@@ -141,7 +143,7 @@ def test_mhn_preparation_rebinds_new_rule_sequence(monkeypatch):
         return torch.full((len(rule_smarts), 4), float(len(calls)))
 
     monkeypatch.setattr(
-        template_based, "rule_fingerprints_from_smarts", fake_rule_fingerprints
+        fingerprints, "rule_fingerprints_from_smarts", fake_rule_fingerprints
     )
     wrapper = _mhn_wrapper(_MHNPolicy())
     first_rules = [_Rule("A"), _Rule("B")]
@@ -165,7 +167,7 @@ def test_mhn_preparation_passes_mhnreact_rdkit_fingerprint_config(monkeypatch):
         return torch.zeros((len(rule_smarts), 4))
 
     monkeypatch.setattr(
-        template_based, "rule_fingerprints_from_smarts", fake_rule_fingerprints
+        fingerprints, "rule_fingerprints_from_smarts", fake_rule_fingerprints
     )
     wrapper = _mhn_wrapper(_MHNRDKitPolicy())
 
@@ -183,9 +185,7 @@ def test_mhn_preparation_uses_query_cgr_rule_graphs(monkeypatch):
         calls.append((tuple(rule_smarts), schema_version))
         return [SimpleNamespace(rule=text) for text in rule_smarts]
 
-    monkeypatch.setattr(
-        template_based, "query_cgr_graphs_from_smarts", fake_rule_graphs
-    )
+    monkeypatch.setattr(rule_features, "query_cgr_graphs_from_smarts", fake_rule_graphs)
     wrapper = _mhn_wrapper(_MHNGraphPolicy())
     rules = [_Rule("A"), _Rule("B")]
 
@@ -200,7 +200,7 @@ def test_mhn_preparation_uses_query_cgr_rule_graphs(monkeypatch):
 
 def test_mhn_association_cache_is_bounded(monkeypatch):
     monkeypatch.setattr(
-        template_based,
+        fingerprints,
         "rule_fingerprints_from_smarts",
         lambda rule_smarts, _config: torch.zeros((len(rule_smarts), 4)),
     )

--- a/tests/unit/ml/test_onnx_policy.py
+++ b/tests/unit/ml/test_onnx_policy.py
@@ -122,13 +122,16 @@ import sys
 class CoreOnly(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path=None, target=None):
         if fullname.split('.')[0] in {'torch', 'torch_geometric', 'chytorch',
-                                      'pytorch_lightning', 'IPython', 'pandas', 'streamlit'}:
+                                      'pytorch_lightning', 'IPython', 'streamlit'}:
             raise AssertionError(f'Base planning imported {fullname}')
 sys.meta_path.insert(0, CoreOnly())
 from synplan.interfaces.cli import synplan
 from synplan.chem.precursor import Precursor
 from synplan.utils.loading import load_policy_function
+from synplan.utils.frames import ChemFrame
 from chython import smiles
+frame = ChemFrame([{'molecule': smiles('CCO')}], depict_columns=['molecule'])
+assert '<svg' in frame._repr_html_()
 policy = load_policy_function(weights_path=sys.argv[1], top_rules=3, policy_type=sys.argv[2])
 assert len(list(policy.predict_reaction_rules_light(Precursor(smiles('CCO')), 7))) == 3
 """,

--- a/tests/unit/ml/test_onnx_policy.py
+++ b/tests/unit/ml/test_onnx_policy.py
@@ -1,0 +1,125 @@
+"""ONNX ranking export preserves the existing policy boundary."""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import torch
+from chython import smiles
+
+pytest.importorskip("onnxruntime")
+pytest.importorskip("onnxscript")
+
+from scripts.export_policy_onnx import export_policy
+from synplan.chem.precursor import Precursor
+from synplan.chem.reaction.rules.vocabulary import RuleLibrary
+from synplan.mcts.policy.template_based import LinearPolicy
+from synplan.ml.config import LinearPolicyNetworkConfig
+from synplan.ml.featurization.molecules import mol_to_numpy, mol_to_pyg
+from synplan.ml.networks.policy.linear import RankingPolicyNetwork
+from synplan.utils.loading import load_policy_function
+
+
+@pytest.mark.parametrize("embedder", ["gcn", "gps"])
+def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
+    torch.manual_seed(42)
+    config = LinearPolicyNetworkConfig(
+        embedder_type=embedder,
+        vector_dim=16,
+        num_conv_layers=1,
+        heads=2,
+        attn_type="multihead",
+    )
+    network = RankingPolicyNetwork(config, n_rules=7).eval()
+    network.hparams["rule_vocabulary_digest"] = "matching-rules"
+    checkpoint, output = tmp_path / "policy.ckpt", tmp_path / "policy.onnx"
+    torch.save(
+        {"hyper_parameters": network.hparams, "state_dict": network.state_dict()},
+        checkpoint,
+    )
+    export_policy(checkpoint, output)
+    policy = load_policy_function(weights_path=output, top_rules=3)
+    reference = LinearPolicy(network, top_rules=3)
+    rules = RuleLibrary(range(7), vocabulary_digest="matching-rules")
+    for smi in ["CC", "CCO", "CC(=O)Oc1ccccc1C(=O)O", "CC(=O)[O-].[Na+]"]:
+        precursor = Precursor(smiles(smi))
+        np.testing.assert_allclose(
+            policy.get_probs(precursor),
+            reference.get_probs(precursor).numpy(),
+            atol=1e-6,
+            rtol=1e-4,
+        )
+        np.testing.assert_allclose(
+            policy.get_logits(precursor),
+            reference.get_logits(precursor).numpy(),
+            atol=1e-5,
+            rtol=1e-4,
+        )
+        expected = list(reference.predict_reaction_rules_light(precursor, 7))
+        actual = list(policy.predict_reaction_rules(precursor, rules))
+        assert [r[2] for r in actual] == [r[1] for r in expected]
+
+    with pytest.raises(ValueError, match="matching trained policy"):
+        list(
+            policy.predict_reaction_rules(
+                precursor, RuleLibrary(range(7), "wrong-rules")
+            )
+        )
+    with pytest.raises(Exception, match="output dimensionality"):
+        list(policy.predict_reaction_rules_light(precursor, 8))
+    with pytest.raises(ValueError, match="ranking only"):
+        load_policy_function(weights_path=output, policy_type="filtering")
+    assert policy.get_probs(Precursor(smiles("[Na+]"))) is None
+
+    # A repeated proposal must use the inherited cache without another ORT call.
+    with monkeypatch.context() as patch:
+        patch.setattr(policy.session, "run", lambda *args: pytest.fail("cache miss"))
+        assert list(policy.predict_reaction_rules(precursor, rules)) == actual
+    policy.rule_prob_threshold = 1.0
+    assert list(policy.predict_reaction_rules(precursor, rules)) == []
+
+    # A fresh process must also run this policy and import the CLI without extras.
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib.abc
+import sys
+class CoreOnly(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split('.')[0] in {'torch', 'torch_geometric', 'chytorch',
+                                      'pytorch_lightning', 'IPython', 'pandas', 'streamlit'}:
+            raise AssertionError(f'Base planning imported {fullname}')
+sys.meta_path.insert(0, CoreOnly())
+from synplan.interfaces.cli import synplan
+from synplan.chem.precursor import Precursor
+from synplan.utils.loading import load_policy_function
+from chython import smiles
+policy = load_policy_function(weights_path=sys.argv[1], top_rules=3)
+assert len(list(policy.predict_reaction_rules_light(Precursor(smiles('CCO')), 7))) == 3
+""",
+            str(output),
+        ],
+        check=True,
+    )
+
+
+def test_molecule_features_preserve_atom_and_edge_schema():
+    molecule = smiles("CCO")
+    arrays = mol_to_numpy(molecule, canonicalize=False)
+    np.testing.assert_array_equal(
+        arrays["x"],
+        [
+            [6, 2, 14, 2, 2, 3, 0, 1, 1, 0, 0],
+            [6, 2, 14, 2, 2, 2, 0, 2, 2, 0, 0],
+            [8, 2, 16, 4, 2, 1, 0, 1, 1, 0, 0],
+        ],
+    )
+    np.testing.assert_array_equal(arrays["edge_index"], [[0, 1, 1, 2], [1, 0, 2, 1]])
+    np.testing.assert_array_equal(arrays["edge_attr"], [[1, 0, 0, 0]] * 4)
+    graph = mol_to_pyg(molecule, canonicalize=False)
+    for name, values in arrays.items():
+        np.testing.assert_array_equal(graph[name].numpy(), values)
+    assert mol_to_numpy(smiles("[Na+].[Cl-]")) is None

--- a/tests/unit/ml/test_onnx_policy.py
+++ b/tests/unit/ml/test_onnx_policy.py
@@ -1,4 +1,4 @@
-"""ONNX ranking export preserves the existing policy boundary."""
+"""ONNX model export preserves the existing policy boundary."""
 
 import subprocess
 import sys
@@ -14,24 +14,34 @@ pytest.importorskip("onnxscript")
 from scripts.export_policy_onnx import export_policy
 from synplan.chem.precursor import Precursor
 from synplan.chem.reaction.rules.vocabulary import RuleLibrary
+from synplan.mcts.config import ValueNetworkEvaluationConfig
 from synplan.mcts.policy.template_based import LinearPolicy
 from synplan.ml.config import LinearPolicyNetworkConfig
 from synplan.ml.featurization.molecules import mol_to_numpy, mol_to_pyg
-from synplan.ml.networks.policy.linear import RankingPolicyNetwork
-from synplan.utils.loading import load_policy_function
+from synplan.ml.networks.policy.linear import (
+    FilteringPolicyNetwork,
+    RankingPolicyNetwork,
+)
+from synplan.ml.networks.value import ValueNetwork
+from synplan.utils.loading import load_evaluation_function, load_policy_function
 
 
 @pytest.mark.parametrize("embedder", ["gcn", "gps"])
-def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
+@pytest.mark.parametrize("policy_type", ["ranking", "filtering"])
+def test_onnx_policy_roundtrip(tmp_path, monkeypatch, embedder, policy_type):
     torch.manual_seed(42)
     config = LinearPolicyNetworkConfig(
         embedder_type=embedder,
+        policy_type=policy_type,
         vector_dim=16,
         num_conv_layers=1,
         heads=2,
         attn_type="multihead",
     )
-    network = RankingPolicyNetwork(config, n_rules=7).eval()
+    network_class = (
+        RankingPolicyNetwork if policy_type == "ranking" else FilteringPolicyNetwork
+    )
+    network = network_class(config, n_rules=7).eval()
     network.hparams["rule_vocabulary_digest"] = "matching-rules"
     checkpoint, output = tmp_path / "policy.ckpt", tmp_path / "policy.onnx"
     torch.save(
@@ -39,7 +49,9 @@ def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
         checkpoint,
     )
     export_policy(checkpoint, output)
-    policy = load_policy_function(weights_path=output, top_rules=3)
+    policy = load_policy_function(
+        weights_path=output, top_rules=3, policy_type=policy_type
+    )
     reference = LinearPolicy(network, top_rules=3)
     rules = RuleLibrary(range(7), vocabulary_digest="matching-rules")
     for smi in ["CC", "CCO", "CC(=O)Oc1ccccc1C(=O)O", "CC(=O)[O-].[Na+]"]:
@@ -59,6 +71,9 @@ def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
         expected = list(reference.predict_reaction_rules_light(precursor, 7))
         actual = list(policy.predict_reaction_rules(precursor, rules))
         assert [r[2] for r in actual] == [r[1] for r in expected]
+        np.testing.assert_allclose(
+            [r[0] for r in actual], [r[0] for r in expected], atol=1e-6
+        )
 
     with pytest.raises(ValueError, match="matching trained policy"):
         list(
@@ -68,8 +83,11 @@ def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
         )
     with pytest.raises(Exception, match="output dimensionality"):
         list(policy.predict_reaction_rules_light(precursor, 8))
-    with pytest.raises(ValueError, match="ranking only"):
-        load_policy_function(weights_path=output, policy_type="filtering")
+    with pytest.raises(ValueError, match="configured policy_type"):
+        load_policy_function(
+            weights_path=output,
+            policy_type="filtering" if policy_type == "ranking" else "ranking",
+        )
     assert policy.get_probs(Precursor(smiles("[Na+]"))) is None
 
     # A repeated proposal must use the inherited cache without another ORT call.
@@ -78,6 +96,20 @@ def test_onnx_ranking_roundtrip(tmp_path, monkeypatch, embedder):
         assert list(policy.predict_reaction_rules(precursor, rules)) == actual
     policy.rule_prob_threshold = 1.0
     assert list(policy.predict_reaction_rules(precursor, rules)) == []
+
+    if policy_type == "filtering":
+        np.testing.assert_allclose(
+            policy.get_filtering_probs_only(precursor),
+            reference.get_filtering_probs_only(precursor).numpy(),
+            atol=1e-6,
+        )
+        for coef in (0.0, 1.0):
+            policy.priority_rules_fraction = reference.priority_rules_fraction = coef
+            np.testing.assert_allclose(
+                policy.get_probs(precursor),
+                reference.get_probs(precursor).numpy(),
+                atol=1e-6,
+            )
 
     # A fresh process must also run this policy and import the CLI without extras.
     subprocess.run(
@@ -97,10 +129,11 @@ from synplan.interfaces.cli import synplan
 from synplan.chem.precursor import Precursor
 from synplan.utils.loading import load_policy_function
 from chython import smiles
-policy = load_policy_function(weights_path=sys.argv[1], top_rules=3)
+policy = load_policy_function(weights_path=sys.argv[1], top_rules=3, policy_type=sys.argv[2])
 assert len(list(policy.predict_reaction_rules_light(Precursor(smiles('CCO')), 7))) == 3
 """,
             str(output),
+            policy_type,
         ],
         check=True,
     )
@@ -123,3 +156,28 @@ def test_molecule_features_preserve_atom_and_edge_schema():
     for name, values in arrays.items():
         np.testing.assert_array_equal(graph[name].numpy(), values)
     assert mol_to_numpy(smiles("[Na+].[Cl-]")) is None
+
+
+def test_onnx_value_roundtrip(tmp_path):
+    torch.manual_seed(42)
+    network = ValueNetwork(vector_dim=16, batch_size=1, num_conv_layers=1).eval()
+    checkpoint, output = tmp_path / "value.ckpt", tmp_path / "value.onnx"
+    torch.save(
+        {"hyper_parameters": network.hparams, "state_dict": network.state_dict()},
+        checkpoint,
+    )
+    export_policy(checkpoint, output, value=True)
+    actual = load_evaluation_function(
+        ValueNetworkEvaluationConfig(weights_path=str(output))
+    )
+    reference = load_evaluation_function(
+        ValueNetworkEvaluationConfig(weights_path=str(checkpoint))
+    )
+    for mols in (["CCO"], ["CC(=O)Oc1ccccc1C(=O)O", "CC"], ["CCCCCCCC", "c1ccccc1O"]):
+        precursors = [Precursor(smiles(smi)) for smi in mols]
+        assert actual.predict_value(precursors) == pytest.approx(
+            reference.predict_value(precursors), abs=1e-6
+        )
+    assert actual.predict_value([Precursor(smiles("[Na+]"))]) == -1e6
+    with pytest.raises(ValueError, match="policy export"):
+        load_policy_function(weights_path=output)

--- a/tests/unit/ml/test_onnx_policy.py
+++ b/tests/unit/ml/test_onnx_policy.py
@@ -104,7 +104,12 @@ def test_onnx_policy_roundtrip(tmp_path, monkeypatch, embedder, policy_type):
             atol=1e-6,
         )
         for coef in (0.0, 1.0):
-            policy.priority_rules_fraction = reference.priority_rules_fraction = coef
+            policy = load_policy_function(
+                weights_path=output,
+                policy_type=policy_type,
+                priority_rules_fraction=coef,
+            )
+            reference.priority_rules_fraction = coef
             np.testing.assert_allclose(
                 policy.get_probs(precursor),
                 reference.get_probs(precursor).numpy(),

--- a/tests/unit/utils/test_loading.py
+++ b/tests/unit/utils/test_loading.py
@@ -1,10 +1,53 @@
 import gzip
+from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
 from synplan.chem.building_blocks import load_building_blocks as catalogue_loader
 from synplan.chem.utils import standardize_smiles_batch
-from synplan.utils.loading import load_building_blocks, load_policy_function
+from synplan.utils.loading import (
+    download_preset,
+    load_building_blocks,
+    load_policy_function,
+)
+
+
+@pytest.mark.parametrize("onnx_available", [True, False])
+def test_download_preset_prefers_onnx_when_available(
+    tmp_path, monkeypatch, onnx_available
+):
+    preset = tmp_path / "preset.yaml"
+    preset.write_text(
+        "files:\n"
+        "  ranking_policy: policy/v1/ranking_policy.ckpt\n"
+        "  reaction_rules: policy/v1/reaction_rules.tsv\n"
+        "  other_policy: policy/v2/ranking_policy.onnx\n",
+        encoding="utf-8",
+    )
+
+    def download(*, repo_id, filename, subfolder, local_dir):
+        assert repo_id == "test/models"
+        if subfolder == "presets":
+            assert filename == "test-preset.yaml"
+            return preset
+        return Path(local_dir) / subfolder / filename
+
+    downloads = Mock(side_effect=download)
+    exists = Mock(return_value=onnx_available)
+    monkeypatch.setattr("synplan.utils.loading.hf_hub_download", downloads)
+    monkeypatch.setattr("synplan.utils.loading.file_exists", exists)
+    paths = download_preset("test-preset", tmp_path, repo_id="test/models")
+    extension = "onnx" if onnx_available else "ckpt"
+    assert paths == {
+        "ranking_policy": tmp_path / f"policy/v1/ranking_policy.{extension}",
+        "reaction_rules": tmp_path / "policy/v1/reaction_rules.tsv",
+        "other_policy": tmp_path / "policy/v2/ranking_policy.onnx",
+    }
+    exists.assert_called_once_with(
+        repo_id="test/models", filename="policy/v1/ranking_policy.onnx"
+    )
+    assert downloads.call_count == 4
 
 
 @pytest.mark.parametrize("extension", [".csv", ".csv.gz", ".tsv", ".tsv.gz"])

--- a/uv.lock
+++ b/uv.lock
@@ -2256,6 +2256,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2571,6 +2587,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -6341,6 +6366,8 @@ all = [
     { name = "adabelief-pytorch" },
     { name = "chytorch-rxnmap-synplan" },
     { name = "chytorch-synplan" },
+    { name = "ipywidgets" },
+    { name = "jupyterlab" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
     { name = "onnx" },
@@ -6389,6 +6416,8 @@ gui = [
 ]
 training = [
     { name = "adabelief-pytorch" },
+    { name = "ipywidgets" },
+    { name = "jupyterlab" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
     { name = "onnx" },
@@ -6407,7 +6436,6 @@ training = [
 [package.dev-dependencies]
 dev = [
     { name = "grpcio-tools" },
-    { name = "jupyterlab" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -6435,6 +6463,8 @@ requires-dist = [
     { name = "frozendict", specifier = ">=2.4.6" },
     { name = "huggingface-hub", specifier = ">=0.24.0" },
     { name = "ijson", specifier = ">=3.4.0" },
+    { name = "ipywidgets", marker = "extra == 'training'", specifier = ">8.1.0" },
+    { name = "jupyterlab", marker = "extra == 'training'", specifier = ">=4.5.7" },
     { name = "matplotlib", marker = "extra == 'training'", specifier = ">=3.7" },
     { name = "matplotlib-venn", marker = "extra == 'training'", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=2" },
@@ -6470,7 +6500,6 @@ provides-extras = ["curation", "training", "gui", "all", "cpu", "cu126", "cu128"
 [package.metadata.requires-dev]
 dev = [
     { name = "grpcio-tools", specifier = ">=1.78.0" },
-    { name = "jupyterlab", specifier = ">=4.5.7" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-xdist", specifier = ">=3.6" },
@@ -7171,6 +7200,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2256,22 +2256,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ipywidgets"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2587,15 +2571,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
-]
-
-[[package]]
-name = "jupyterlab-widgets"
-version = "3.0.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -6354,6 +6329,7 @@ dependencies = [
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "pandas" },
+    { name = "protobuf" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rdkit" },
@@ -6365,8 +6341,6 @@ all = [
     { name = "adabelief-pytorch" },
     { name = "chytorch-rxnmap-synplan" },
     { name = "chytorch-synplan" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
     { name = "onnx" },
@@ -6383,6 +6357,7 @@ all = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch-geometric" },
+    { name = "torchmetrics" },
 ]
 cpu = [
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -6414,8 +6389,6 @@ gui = [
 ]
 training = [
     { name = "adabelief-pytorch" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
     { name = "onnx" },
@@ -6428,6 +6401,7 @@ training = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch-geometric" },
+    { name = "torchmetrics" },
 ]
 
 [package.dev-dependencies]
@@ -6461,8 +6435,6 @@ requires-dist = [
     { name = "frozendict", specifier = ">=2.4.6" },
     { name = "huggingface-hub", specifier = ">=0.24.0" },
     { name = "ijson", specifier = ">=3.4.0" },
-    { name = "ipykernel", marker = "extra == 'training'", specifier = ">6.29.0" },
-    { name = "ipywidgets", marker = "extra == 'training'", specifier = ">8.1.0" },
     { name = "matplotlib", marker = "extra == 'training'", specifier = ">=3.7" },
     { name = "matplotlib-venn", marker = "extra == 'training'", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=2" },
@@ -6471,6 +6443,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.23" },
     { name = "onnxscript", marker = "extra == 'training'", specifier = ">=0.5" },
     { name = "pandas", specifier = ">=1.4" },
+    { name = "protobuf", specifier = ">=6.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytorch-lightning", marker = "extra == 'training'", specifier = ">=2.3.3,!=2.6.2,!=2.6.3" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -6489,6 +6462,7 @@ requires-dist = [
     { name = "torch-geometric", marker = "extra == 'cu126'", specifier = ">=2.4.0" },
     { name = "torch-geometric", marker = "extra == 'cu128'", specifier = ">=2.4.0" },
     { name = "torch-geometric", marker = "extra == 'training'", specifier = ">=2.4.0" },
+    { name = "torchmetrics", marker = "extra == 'training'", specifier = ">=1.0" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
 provides-extras = ["curation", "training", "gui", "all", "cpu", "cu126", "cu128"]
@@ -7197,15 +7171,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -808,6 +808,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "comm"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2280,6 +2292,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (python_full_version >= '3.11' and extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (python_full_version >= '3.11' and extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (sys_platform != 'win32' and extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (sys_platform != 'win32' and extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (sys_platform != 'win32' and extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -4721,7 +4745,7 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.3"
+version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
@@ -4731,6 +4755,7 @@ resolution-markers = [
     "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
+    { name = "coloredlogs", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "flatbuffers", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -4738,30 +4763,28 @@ dependencies = [
     { name = "sympy", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
-    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
-    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
-    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
-    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
-    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
-    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
-    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/db/db/81bf3d7cecfbfed9092b6b4052e857a769d62ed90561b410014e0aae18db/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36", size = 19153079, upload-time = "2025-10-27T23:05:57.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/a382452b17cf70a2313153c520ea4c96ab670c996cb3a95cc5d5ac7bfdac/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f7d1fe034090a1e371b7f3ca9d3ccae2fabae8c1d8844fb7371d1ea38e8e8d2", size = 15219883, upload-time = "2025-10-22T03:46:21.66Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/179bf90679984c85b417664c26aae4f427cba7514bd2d65c43b181b7b08b/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ca88747e708e5c67337b0f65eed4b7d0dd70d22ac332038c9fc4635760018f7", size = 17370357, upload-time = "2025-10-22T03:46:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6d/738e50c47c2fd285b1e6c8083f15dac1a5f6199213378a5f14092497296d/onnxruntime-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:0be6a37a45e6719db5120e9986fcd30ea205ac8103fd1fb74b6c33348327a0cc", size = 13467651, upload-time = "2025-10-27T23:06:11.904Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
 ]
 
 [[package]]
@@ -5617,6 +5640,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
 ]
 
 [[package]]
@@ -6976,7 +7008,7 @@ dependencies = [
     { name = "ijson" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -7095,7 +7127,8 @@ requires-dist = [
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=2" },
     { name = "numpy", specifier = ">=2" },
     { name = "onnx", marker = "extra == 'onnx-export'", specifier = ">=1.17" },
-    { name = "onnxruntime", specifier = ">=1.23" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = ">=1.23,<1.24" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.23" },
     { name = "onnxscript", marker = "extra == 'onnx-export'", specifier = ">=0.5" },
     { name = "pandas", marker = "extra == 'gui'", specifier = ">=1.4" },
     { name = "pandas", marker = "extra == 'notebooks'", specifier = ">=1.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,23 +3,28 @@ revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
@@ -891,19 +896,24 @@ version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
@@ -1168,7 +1178,8 @@ version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -1205,7 +1216,8 @@ version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -1247,7 +1259,8 @@ version = "12.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -1296,7 +1309,8 @@ version = "12.8.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -1345,7 +1359,8 @@ version = "13.0.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -1386,15 +1401,6 @@ nvrtc = [
 ]
 nvtx = [
     { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128') or (sys_platform == 'win32' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-
-[[package]]
-name = "custom-inherit"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/fa/c4619d463cb76d88ffc383c2115883219efffa55e7ecd0ff972cd0034f29/custom_inherit-2.4.1.tar.gz", hash = "sha256:7052eb337bcce83551815264391cc4efc2bf70b295a3c52aba64f1ab57c3a8a2", size = 31193, upload-time = "2023-02-18T19:41:30.306Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/0c/f0967273bd2213adaafbd8754fa36f03ba21273ce03f70a83551fe12b0f1/custom_inherit-2.4.1-py3-none-any.whl", hash = "sha256:313f9594d98e79a7fbf58d9ad368fd29adc97572d886975dbd8c7032b14abc6a", size = 15847, upload-time = "2023-02-18T19:41:28.841Z" },
 ]
 
 [[package]]
@@ -1503,19 +1509,24 @@ version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
@@ -1615,6 +1626,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -3008,19 +3027,6 @@ wheels = [
 ]
 
 [[package]]
-name = "loguru"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
-]
-
-[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -3057,19 +3063,24 @@ version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
@@ -3316,6 +3327,47 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/72/307d7c4bd0600601c7133fba5cb78af7db968152951c1cd473abb1cda782/ml_dtypes-0.6.0.tar.gz", hash = "sha256:5e60251d32ced5598972e4d5e06a2f044341f9291402551a3f6f0ec44f9299b0", size = 3032327, upload-time = "2026-08-13T14:14:40.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/15/01285c64133ea38abf3b990a704d7d30e50daea2806d150bcc4163495d35/ml_dtypes-0.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bad8d1dd5bed060a29332b99d63d0e5c2969081e1c6ea54adfbccfdfa783be44", size = 566808, upload-time = "2026-08-13T14:13:50.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/850d9b8b35549182f7c7f2cf742ce75c853ee880101bbc51cca0d62732e3/ml_dtypes-0.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:008382aeab529df5d3f00501ad9a7dcd64494d4b5b1971fc4c79019e6c1f5010", size = 356865, upload-time = "2026-08-13T14:13:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/15/844f5402145ce73bec8eb3afeb9f41d2bf99e0c8617c93f9e9886f26b419/ml_dtypes-0.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ec0d244a5bba12239025389ad88bbfb45f9f10e25ab4f678e9a4768ebd47532", size = 412036, upload-time = "2026-08-13T14:13:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/63/efc9257a1ef0f53dfc76dedfe70d7d35118fbcdb810bb48cb7323ebd0b87/ml_dtypes-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:03ce583adfce34ad33aa9e1fc7a8344dcf90ea776cc4ef0e5a48d4eae84e5d20", size = 433668, upload-time = "2026-08-13T14:13:53.668Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2c/318cd1a9014c63939ffe687e19559ae12831fcc37d66c71ad1f616f1ffd6/ml_dtypes-0.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f4f59f83c82ab480e924b988e7b1b4eb4de836dfcf5390c6f59148d1a00e1d02", size = 566813, upload-time = "2026-08-13T14:13:55.053Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/83/706b8a39449f0d55a7d5f7d07a169da4decfafae8a1f4983a9236d4b49e8/ml_dtypes-0.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7728c0420ec1c338564fc8b01015ff2d58567e70f17fedce5a0a7c0308c0d5b9", size = 356864, upload-time = "2026-08-13T14:13:56.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b1/135a7bf47633f5b9184f0d0316af819884124d12b40965064bd216266514/ml_dtypes-0.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c8e39b53e90afda8ce52859c93de4dba3e02b76d85dcf091cc469f9184c6dae", size = 412043, upload-time = "2026-08-13T14:13:57.614Z" },
+    { url = "https://files.pythonhosted.org/packages/07/23/8870bb62d6e499d6bcbc1242b9f11689bae00a3d39d3684a9aefad8b6ee6/ml_dtypes-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:3035518e3e19add1a4cac9236ab22888b208a4074912514313ccb2d6d242cde8", size = 433670, upload-time = "2026-08-13T14:13:59.097Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7a/5d8fbe24d0bffd0d7cb5165a89f8ab7c3de000f26d6705242aeed99d583c/ml_dtypes-0.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:5a519c9e95a216fbcb8e759793ef7fb40793fc803ed839142d6dc5be9be5bc89", size = 551915, upload-time = "2026-08-13T14:14:00.368Z" },
+    { url = "https://files.pythonhosted.org/packages/84/6a/441eb053b078954f7fea284dfb288701884d0a1404d39babb858e1649023/ml_dtypes-0.6.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5359c588cc62de6f78d7430f06b65853d884955494d86d6ad90b6dd64a3f3a08", size = 565447, upload-time = "2026-08-13T14:14:01.737Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cf/87e8a6c57eed63a91782a0d229856ddf73e138ce004dd71e2799a9dcdb33/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37da32aa97749251025666d62372775019594577b9c9e9cfda83bed48d778fdb", size = 360227, upload-time = "2026-08-13T14:14:02.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f9/7d76c1eae866f5d4636401b31b6d6dd90e4b4ced1fa7cfdfcca9c60e4bd3/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b4a480aa8fd54a1805b8ac10f3f91763926a74f73c0c364c10f9231854f4170", size = 409890, upload-time = "2026-08-13T14:14:04.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/9c61ec2760b5cbfb1c6558d5c991a6d8fd3271053c32db20506a9a90272b/ml_dtypes-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:2a3e9d53925597fbffafd2a37048dadeddd0bdaba58058f6ae0869ed709a184d", size = 439333, upload-time = "2026-08-13T14:14:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/57/780ca3e5ab135b9fbdd8e5441abf5f801b30398371b691291e05ab9834c0/ml_dtypes-0.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:6eaed129a4afe90694b8685e2f9b6294849f5eda4af9a15be83a4326eeebd775", size = 552268, upload-time = "2026-08-13T14:14:06.866Z" },
+    { url = "https://files.pythonhosted.org/packages/50/51/fd1582b8f5ed8a9e7be0e161a6ea0dff70cb280479a12178df0b3a72700e/ml_dtypes-0.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:084dfe51a7ad58b171f05115f8226ed4233a454a1611371947e806e76f0c638d", size = 565468, upload-time = "2026-08-13T14:14:08.5Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/22/20fd70ca6ed12446cb92d5b2a7745bd185f9d8b8cdeeadad976574398e6b/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28d676428b104bb9717b0928bc5c5129f2d6b51b6727587cc4289e7bf8713cb5", size = 360232, upload-time = "2026-08-13T14:14:09.873Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a5/da8ae6c6f1babe4b68e3e55d43d39b529e29774f10e0910671a6b8c86eb8/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26b1f1fa4f0435a2946859823f6e2bf06796f1e9f10f5a05b08a5e3c8f46ff69", size = 410169, upload-time = "2026-08-13T14:14:11.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/55/4561acefa00fa4bcbfb82ca6a48578b41f372cd7dd7cdd6eb4720abc2e5f/ml_dtypes-0.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:fb87f46b4f7ad7b5d3ad8f4b452b024bd4229d44c8ff934798c1fe656210387a", size = 439357, upload-time = "2026-08-13T14:14:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5d/6a01538e507ef0ed5e879985b13a92467bf8960696fb1131f8b8cadc60ff/ml_dtypes-0.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:57ed0d6b4ac5e7868361303a9c57fbcf63b768236ee14456f585dfcf260d0292", size = 552278, upload-time = "2026-08-13T14:14:13.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7a/97dc35667b7c9db33c5344c673cd27f87e34771875ea7100138726132ac9/ml_dtypes-0.6.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:84fa136b8602c8c39e3b6cb24918960cd6f36cade7a70376f56770729cd56510", size = 562551, upload-time = "2026-08-13T14:14:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/77f0ede10558d0d935da2e3276ed7e9c8cc2bad3463b9a0b66b03fc60be2/ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:317be9967fb84b0ce4e80e6b1bf71213d21971621cf6f1e501a63602a95297bf", size = 360334, upload-time = "2026-08-13T14:14:16.079Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b1/1831dd8c9b06c013085d31a2ac4f03392d43bd36bfc6ff591a08bcedc1cf/ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f490c003369ce60e514a0c3b12374f05274c101fee1bead6740ec8a564032b0", size = 409966, upload-time = "2026-08-13T14:14:17.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ad/9c32c53f823dda3742df19a79c10bc198365937873ea125ba65747440c23/ml_dtypes-0.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:d574c2b28921dc72e869df248f1a278f6eee176a1f237c8642e1a71eb15f3977", size = 457224, upload-time = "2026-08-13T14:14:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/dd98205418a13353d41c52bf5326d8cbec515aace46174e23c6ea01c2978/ml_dtypes-0.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:f4adb4af61516510d786cf8c01851a66f6d3ddfa79e1144deaa5b40d8507231e", size = 568378, upload-time = "2026-08-13T14:14:19.843Z" },
+    { url = "https://files.pythonhosted.org/packages/65/36/32e7beef3281fed74883451477ad976364323206dbfaa95e948ba788dac7/ml_dtypes-0.6.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3e169214e0d80ff1c038e1b3017e33c23e43bdf948d42d31de8283111c7e2fa3", size = 590177, upload-time = "2026-08-13T14:14:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/99b3d9b3c984b3bd1e81d8244f1fa2f812e44060d853205b2df6271aa17c/ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:573b11f3c327e17ef3826d266e676cf1149a1f3016f822a05f2306c55d8246bf", size = 363142, upload-time = "2026-08-13T14:14:22.463Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fb/8091c0aee7f2712de99c7fd4b1642382644dec6a4962effe4f5b9d16a973/ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b76fa1d3f92967d58289ac47ab7458ede66e6f3527fff3e59142aee57d9307cd", size = 430645, upload-time = "2026-08-13T14:14:23.737Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/962d2c589513b5930d05b6eae5fbd22ad8bbcf26bb763449f3d8f912360f/ml_dtypes-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3be9911d953f97cddded4b9961d7b650473b7e55806d20f6176f8356dfe7b38e", size = 465667, upload-time = "2026-08-13T14:14:25.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/bcb25e246edd19af5fa1cf6267040bd9977a7afca846e6cfd4a52078b44f/ml_dtypes-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e74266ca8e97874a937b7646378c178025650a236584f7474d10d8086a6edea3", size = 572706, upload-time = "2026-08-13T14:14:26.296Z" },
+]
+
+[[package]]
 name = "mlflow"
 version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3556,15 +3608,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multipledispatch"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385, upload-time = "2023-06-27T16:45:11.074Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818, upload-time = "2023-06-27T16:45:09.418Z" },
-]
-
-[[package]]
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3594,19 +3637,24 @@ version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
@@ -3738,19 +3786,24 @@ version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
@@ -3879,19 +3932,24 @@ version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -3985,7 +4043,8 @@ version = "12.6.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4001,7 +4060,8 @@ version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4027,7 +4087,8 @@ version = "12.6.80"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4045,7 +4106,8 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4071,7 +4133,8 @@ version = "12.6.85"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4087,7 +4150,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4113,7 +4177,8 @@ version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4131,7 +4196,8 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4147,7 +4213,8 @@ version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4166,7 +4233,8 @@ version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4211,7 +4279,8 @@ version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4232,7 +4301,8 @@ version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4260,7 +4330,8 @@ version = "1.11.1.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4275,7 +4346,8 @@ version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4300,7 +4372,8 @@ version = "10.3.7.77"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4318,7 +4391,8 @@ version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4349,7 +4423,8 @@ version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4372,7 +4447,8 @@ version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4406,7 +4482,8 @@ version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4427,7 +4504,8 @@ version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4494,7 +4572,8 @@ version = "12.6.85"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4510,7 +4589,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4554,7 +4634,8 @@ version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4572,7 +4653,8 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -4580,6 +4662,183 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
     { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
+]
+
+[[package]]
+name = "onnx"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/471f234e2716c83f17a26e1b50cd64c39428373e91dd018aafb3d499c108/onnx-1.22.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:6d0ffffd63a4ecc21ddaeddd5bf02099cb701aa4243f2de00122726869065ca4", size = 20167110, upload-time = "2026-06-15T12:48:59.152Z" },
+    { url = "https://files.pythonhosted.org/packages/99/40/540a2fe3c49ce1709ff2015de20d9a351264fb442f8998f92cf0ba7e279e/onnx-1.22.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33ce94119bbb7f05d9caea4ea7549f5185a54369f6bbc9f70171bd5ee6935bbc", size = 18892738, upload-time = "2026-06-15T12:49:02.139Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/0c/f41d5b89c38fb2ec410ab23c24fa110af786093b140644f7f953e436743b/onnx-1.22.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87a3077958f66f9a26dec10077ac28326d9cec2cbe1f0b040947243449754573", size = 19110354, upload-time = "2026-06-15T12:49:05.031Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8e/9f41d132855e93c2808cdd4afab1b5af67bd5e82e4a4fa9248006e4df87e/onnx-1.22.0-cp310-cp310-win32.whl", hash = "sha256:8a5eccce2d5fc6c5046928a9aa7cdd9750ea4a586f8de341d3d40d820c35fdec", size = 17083595, upload-time = "2026-06-15T12:49:08.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/52/86caff81786a5428485795c79175ae2b12a630795bcb267b84e5f9e98450/onnx-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:5c1c0408a9d4b4df33851672e5fc7590b96301ee123396d608f9ab6f045ab06b", size = 17215270, upload-time = "2026-06-15T12:49:11.483Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/55/30825c02c92a0380ce84c3feeeec95d329fa77548ba58cb10ad4bbfd83c6/onnx-1.22.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2d8f229a553fa440fe623ed7b36fca5e7762da3af871c3f8f8ce451df73e2914", size = 20167891, upload-time = "2026-06-15T12:49:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/24/cd4ab52ecaf41c3fbed674772ccbfe39041cb257b8471a47a37e48bff3f8/onnx-1.22.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a89a7cb9ba13d78f009bdec448ec82a98972589734f157022a2bff7a5973a6", size = 18892720, upload-time = "2026-06-15T12:49:16.904Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/c9d9d56ceadb1c0a90a7cbec5a0510520ab6538938944fa84548e4b5b054/onnx-1.22.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d0a2bdb15eb2b3cb65c438f3423d9620d14fdce32f92380e6bb1b2e09568ef5", size = 19110720, upload-time = "2026-06-15T12:49:19.812Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/e43e5a68d9cadde55df75310027f87127333a77e5ddcea14c73e96a10cac/onnx-1.22.0-cp311-cp311-win32.whl", hash = "sha256:239958534464612fbcb6ed23d5228aaa925b39b8773f58726809ffdccb4edd1c", size = 17083746, upload-time = "2026-06-15T12:49:22.935Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/cc0a9f2cf4522e42829d089927b4b75924d32f50dca237482e7b741df003/onnx-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:8561a2c00041c07e08db0c228593b5b4694100398685f348532af7dbb84189da", size = 17215684, upload-time = "2026-06-15T12:49:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/0f049f9eaa06c8383060c5f0a338e3a6caac8822e6e326c9162f05abf95a/onnx-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:8907b9b9389893bc0dc6314cc00ee1e3a69844e48d689eacc6a0340411a7da58", size = 17210398, upload-time = "2026-06-15T12:49:29.091Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/6a/481561f1093834376ed493e4ca42a73e5be0d50031f2969c86593bdc7c96/onnx-1.22.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:596fbf0490947533c1c1045ba860851dc9fb77471023dac9a71ba5b42ceab103", size = 20167081, upload-time = "2026-06-15T12:49:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/84/55/b34fc2aa30aa54b4a775402d24c4082242c720283a274fe976ac8eb94480/onnx-1.22.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae5a563f281cd9d2845622cecf6c092a57e4ee1b138f66fdbbdd4200567a5e16", size = 18889249, upload-time = "2026-06-15T12:49:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a6/bd32357e6cc1ecb473afd78193d7231724f284435d2db25696ecfaaa1503/onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b", size = 19106514, upload-time = "2026-06-15T12:49:37.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9d/3af461ac6c714b8b369cb71499659932f4f12cfb066250b62f7567c3d530/onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c", size = 16966387, upload-time = "2026-06-15T12:49:40.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/68195b5e5a53e333faf2660f5352ee43738d0e42fc5216cc6b1871a9fbfb/onnx-1.22.0-cp312-abi3-win32.whl", hash = "sha256:cc8b66b312f8f03a53e268afb67180a2d97dd12cc79e2b61361c6c0073448016", size = 17081568, upload-time = "2026-06-15T12:49:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a8/734725bb703c5fabb687f79c79e51249475212b3eb37771ac4a4ac9b487f/onnx-1.22.0-cp312-abi3-win_amd64.whl", hash = "sha256:72ccebab3bac07215c204ce8848d42e78eaaa666badbf72d25cd359b9f269e3a", size = 17213290, upload-time = "2026-06-15T12:49:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/8ce48d8ae26a8761ad4e5dc771961b155c5c3c7c8540ec7f2f2d71b69af0/onnx-1.22.0-cp312-abi3-win_arm64.whl", hash = "sha256:f3c120dcdb70ad738f3c061b32798f408ea299eb69f84dd69ab4a6bf3c2ec01f", size = 17207030, upload-time = "2026-06-15T12:49:48.635Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/13/47323b97846387848efb1044ded11bb94b83526f3d1fbdb37c6480d4520f/onnx-1.22.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:19e45e4af88e3fe3261458d4b8cc461957ae2782a358a3560503569bf3b23b72", size = 20176465, upload-time = "2026-06-15T12:49:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0c/d3b8a7e7eee123938586c608bb9894b5723f2342b9450c0eec59fbec7099/onnx-1.22.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c21a0e59fd967a95b358e4a6e756d1f1eec2d304a83480f329f66e30d2bf0223", size = 18894028, upload-time = "2026-06-15T12:49:54.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8a/da2a97ab46fe6e0cd9beb3ac14603a22f5be492f9ca347faf8233a07bb33/onnx-1.22.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2632406b8f523ef2e2873c363f90b20a3d88c0fbcfac757d3addffccf8f452c2", size = 19110420, upload-time = "2026-06-15T12:49:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/ce984063017518307ebfaa545782fc400e593dc2d7fdf4f23ce4be1ed197/onnx-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3a39fc4643867aecb33417fdddb11e308ee79d2d4a584b9d50cc7aec2091b13", size = 17237547, upload-time = "2026-06-15T12:50:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/257a880384a1dd502d543b0067945074d63cd17d0840e958355bc8197da8/onnx-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:8e268cdc0547e3949799ffd4a44451dc2b9080b57d0824a2db680b6ec65506f0", size = 17231391, upload-time = "2026-06-15T12:50:03.047Z" },
+]
+
+[[package]]
+name = "onnx-ir"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "onnx" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/c2/61194cec0dbc5622273c0ebd592d37cc1dca0d7f1a744f02edd45ac905a3/onnx_ir-1.0.0.tar.gz", hash = "sha256:9e261f25fde8da9612ae5cb43b3b374d5ff469c04af0363cad588b2bb000b812", size = 163121, upload-time = "2026-08-11T14:49:46.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cd/6d1637172eb59c7b18ac90ed089d1f599a11fe0e63b4db2d017f3bb38a32/onnx_ir-1.0.0-py3-none-any.whl", hash = "sha256:e578f0d608d3062866b48223616eb2d10a6d6d01f8b8faac596129034f483cc7", size = 185849, upload-time = "2026-08-11T14:49:45.524Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "protobuf", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "sympy", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "protobuf", marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/8bd3e0008ff8d386305351109a7329ea57e51a3ab57bc92340f29c4a5b5d/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:16925ef8497e2c07e4b5ae15b504079b3ab3f65e22c58efd10dde0f3caea969a", size = 20803602, upload-time = "2026-08-17T22:53:36.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/91/a66cd77f28379ede419672edda3184f1eb286db215dce1e7b976fae2d63b/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85f8e8406c52658735fe5c7fbfd3ebaa1ed340768324f6252e4274e374580a23", size = 23113193, upload-time = "2026-08-17T22:53:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/82/2da968405c42340f03de0bcdb63be09ae1004f820b2295590d48951b5cf2/onnxruntime-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4f427afac434b0070fe992b540ddf20a7aff2265f760f314d91331935b6b98", size = 13999253, upload-time = "2026-08-17T22:53:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/70c9c893bf732ee66124c2d8de6a21fc9361ec62cf378f857043efcbf0eb/onnxruntime-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:4eae472cf7dc3107dec1bb53cd6d142d1964616d08aae48654cd4254b2363c4b", size = 13741410, upload-time = "2026-08-17T22:53:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/80/381c1e9efed9cc32d00aa7cab0547dc84116cec906c3ffe3613686d6963a/onnxruntime-1.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3a3814c041251d6a77fdf513fb282056538ee826d2f1178a0df3c549d3fff6ba", size = 21430049, upload-time = "2026-08-17T22:53:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/4be0e345d38fe707a701ca07e8f63c05b152a2e6285d1e43a7faf63fedd2/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2fb19e848f7c33ed8d3182b52504aaa11c5e8da438bbb47296f85b133cbcf6b", size = 20816870, upload-time = "2026-08-17T22:53:51.169Z" },
+    { url = "https://files.pythonhosted.org/packages/96/eb/e6968f5e41aac3125f2ff5708855f09cb0b70d85ed3115b625b0b58305ba/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b80d8c7ec2cc7438e4da3760b88c24568cba72c9ace96d668800a6c79419acb", size = 23136745, upload-time = "2026-08-17T22:53:53.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/80/5b28f1f1111210fc4a336ddbc6950f468ebf9a6a265420568f4f43fa33ce/onnxruntime-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:4acf2b4948b7ede87221ca6332344b8facdc8059d6ac751a7d367d04532b02dd", size = 14001407, upload-time = "2026-08-17T22:53:56.486Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/6883f89ea4b044e6e8447ebfaf9bcecdf457b7d80a683635e130b25498e0/onnxruntime-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:dc61a79cb39afd66ab3f01fd2c23591a7f01de89c1668e1fb6315067fc279164", size = 13746981, upload-time = "2026-08-17T22:53:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
+]
+
+[[package]]
+name = "onnxscript"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "onnx" },
+    { name = "onnx-ir" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/01/3e3fab8d643ca097ea4aa9e51246643699dfaaa0650589744fe44bc46651/onnxscript-0.7.2.tar.gz", hash = "sha256:2c664f6383d10f332a4d47b2876dcab16dba84909fe703656b19abc281fda165", size = 646719, upload-time = "2026-09-09T17:06:44.567Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/3b/06260997cdc41138e58718588a6c87d0eb342bbe0dda8a6aae91d163c384/onnxscript-0.7.2-py3-none-any.whl", hash = "sha256:d0e7121c6a1eefd608058928e111cbdb76709f70d269ff0d07aee493bd1d13c9", size = 754215, upload-time = "2026-09-09T17:06:46.442Z" },
 ]
 
 [[package]]
@@ -5361,15 +5620,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pypng"
-version = "0.20220715.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5737,19 +5987,6 @@ wheels = [
 ]
 
 [[package]]
-name = "reportlab"
-version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "charset-normalizer" },
-    { name = "pillow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/23/b8a8b9a5e596ce3de71237c8d6c6a976c763e930878b16340aff3d67ed53/reportlab-4.5.0.tar.gz", hash = "sha256:e595932789ab7a107ba253e83f7815622708a9fd49920d0d6a909880eb66ac75", size = 3914127, upload-time = "2026-04-29T09:12:26.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/13/bc43591a54dd38ac5c19e7e849f0311d879737a0d07e032e5be79849a5fb/reportlab-4.5.0-py3-none-any.whl", hash = "sha256:b8cc8996947d84e805368b47b2376070966f091d029351a0d8a1f238984c2c7f", size = 1957238, upload-time = "2026-04-29T09:12:22.904Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6072,19 +6309,24 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
@@ -6202,19 +6444,24 @@ version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
@@ -6468,15 +6715,20 @@ version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
     "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
+    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -6717,50 +6969,88 @@ name = "synplanner"
 version = "1.8.0"
 source = { editable = "." }
 dependencies = [
-    { name = "adabelief-pytorch" },
     { name = "chython-synplan", extra = ["racer-default"] },
-    { name = "chytorch-rxnmap-synplan" },
-    { name = "chytorch-synplan" },
     { name = "click" },
     { name = "frozendict" },
     { name = "huggingface-hub" },
     { name = "ijson" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
-    { name = "matplotlib" },
-    { name = "matplotlib-venn" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "pandas" },
-    { name = "protobuf" },
+    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "pydantic" },
-    { name = "pytorch-lightning" },
     { name = "pyyaml" },
     { name = "rdkit" },
-    { name = "safetensors" },
-    { name = "streamlit" },
-    { name = "streamlit-ketcher" },
-    { name = "torch-geometric" },
-    { name = "toytree" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
 cpu = [
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch-geometric" },
 ]
 cu126 = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
+    { name = "torch-geometric" },
 ]
 cu128 = [
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torch-geometric" },
+]
+gui = [
+    { name = "pandas" },
+    { name = "streamlit" },
+    { name = "streamlit-ketcher" },
 ]
 loggers = [
     { name = "mlflow" },
     { name = "wandb" },
 ]
+mapping = [
+    { name = "chytorch-rxnmap-synplan" },
+    { name = "chytorch-synplan" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+]
 mlflow = [
     { name = "mlflow" },
+]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "matplotlib" },
+    { name = "matplotlib-venn" },
+    { name = "pandas" },
+]
+onnx-export = [
+    { name = "onnx" },
+    { name = "onnxscript" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch-geometric" },
+]
+torch = [
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch-geometric" },
+]
+training = [
+    { name = "adabelief-pytorch" },
+    { name = "pytorch-lightning" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch-geometric" },
 ]
 wandb = [
     { name = "wandb" },
@@ -6774,6 +7064,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "synplanner", extra = ["mapping", "notebooks", "onnx-export", "training"] },
     { name = "twine" },
 ]
 docs = [
@@ -6788,39 +7079,50 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adabelief-pytorch", specifier = ">=0.2.1" },
+    { name = "adabelief-pytorch", marker = "extra == 'training'", specifier = ">=0.2.1" },
     { name = "chython-synplan", extras = ["racer-default"], specifier = "==1.108" },
-    { name = "chytorch-rxnmap-synplan", specifier = ">=1.7" },
-    { name = "chytorch-synplan", specifier = ">=1.70" },
+    { name = "chytorch-rxnmap-synplan", marker = "extra == 'mapping'", specifier = ">=1.7" },
+    { name = "chytorch-synplan", marker = "extra == 'mapping'", specifier = ">=1.70" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "frozendict", specifier = ">=2.4.6" },
     { name = "huggingface-hub", specifier = ">=0.24.0" },
     { name = "ijson", specifier = ">=3.4.0" },
-    { name = "ipykernel", specifier = ">6.29.0" },
-    { name = "ipywidgets", specifier = ">8.1.0" },
-    { name = "matplotlib", specifier = ">=3.7" },
-    { name = "matplotlib-venn", specifier = ">=1.1" },
+    { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">6.29.0" },
+    { name = "ipywidgets", marker = "extra == 'notebooks'", specifier = ">8.1.0" },
+    { name = "matplotlib", marker = "extra == 'notebooks'", specifier = ">=3.7" },
+    { name = "matplotlib-venn", marker = "extra == 'notebooks'", specifier = ">=1.1" },
     { name = "mlflow", marker = "extra == 'loggers'", specifier = ">=2" },
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=2" },
     { name = "numpy", specifier = ">=2" },
-    { name = "pandas", specifier = ">=1.4" },
-    { name = "protobuf", specifier = ">=6.0" },
+    { name = "onnx", marker = "extra == 'onnx-export'", specifier = ">=1.17" },
+    { name = "onnxruntime", specifier = ">=1.23" },
+    { name = "onnxscript", marker = "extra == 'onnx-export'", specifier = ">=0.5" },
+    { name = "pandas", marker = "extra == 'gui'", specifier = ">=1.4" },
+    { name = "pandas", marker = "extra == 'notebooks'", specifier = ">=1.4" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytorch-lightning", specifier = ">=2.3.3,!=2.6.2,!=2.6.3" },
+    { name = "pytorch-lightning", marker = "extra == 'training'", specifier = ">=2.3.3,!=2.6.2,!=2.6.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rdkit", specifier = ">=2023.9.1" },
-    { name = "safetensors", specifier = ">=0.4" },
-    { name = "streamlit", specifier = ">1.35.1" },
-    { name = "streamlit-ketcher", specifier = ">=0.0.1" },
+    { name = "safetensors", marker = "extra == 'training'", specifier = ">=0.4" },
+    { name = "scipy", marker = "extra == 'mapping'", specifier = ">=1.10" },
+    { name = "streamlit", marker = "extra == 'gui'", specifier = ">1.35.1" },
+    { name = "streamlit-ketcher", marker = "extra == 'gui'", specifier = ">=0.0.1" },
+    { name = "synplanner", extras = ["torch"], marker = "extra == 'cpu'" },
+    { name = "synplanner", extras = ["torch"], marker = "extra == 'cu126'" },
+    { name = "synplanner", extras = ["torch"], marker = "extra == 'cu128'" },
+    { name = "synplanner", extras = ["torch"], marker = "extra == 'onnx-export'" },
+    { name = "synplanner", extras = ["torch"], marker = "extra == 'training'" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "synplanner", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cu126'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "synplanner", extra = "cu126" } },
     { name = "torch", marker = "extra == 'cu128'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "synplanner", extra = "cu128" } },
-    { name = "torch-geometric", specifier = ">=2.4.0" },
-    { name = "toytree", specifier = ">=2.0" },
+    { name = "torch", marker = "extra == 'onnx-export'", specifier = ">=2.6" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0" },
+    { name = "torch-geometric", marker = "extra == 'torch'", specifier = ">=2.4.0" },
+    { name = "tqdm", specifier = ">=4.66" },
     { name = "wandb", marker = "extra == 'loggers'", specifier = ">=0.17" },
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.17" },
 ]
-provides-extras = ["cpu", "cu126", "cu128", "wandb", "mlflow", "loggers"]
+provides-extras = ["torch", "training", "mapping", "notebooks", "gui", "onnx-export", "cpu", "cu126", "cu128", "wandb", "mlflow", "loggers"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6830,6 +7132,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.14.4,<0.15" },
+    { name = "synplanner", extras = ["training", "mapping", "notebooks", "onnx-export"] },
     { name = "twine", specifier = ">=6.2.0,<7" },
 ]
 docs = [
@@ -6963,7 +7266,8 @@ version = "2.11.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -6993,7 +7297,8 @@ version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -7051,7 +7356,8 @@ version = "2.11.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
@@ -7102,7 +7408,8 @@ version = "2.11.0+cu126"
 source = { registry = "https://download.pytorch.org/whl/cu126" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -7153,7 +7460,8 @@ version = "2.11.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -7254,44 +7562,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
     { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
     { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
-]
-
-[[package]]
-name = "toyplot"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "arrow" },
-    { name = "custom-inherit" },
-    { name = "multipledispatch" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "packaging" },
-    { name = "pypng" },
-    { name = "reportlab" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/69e7b08619919721a13c805782860e140e9b8e86863dee1322d9c85f6129/toyplot-2.1.0.tar.gz", hash = "sha256:ea773bee79e1d6adab08dcc58af6b82e82801575d0b8b23b477a6557f49fb0e7", size = 8061236, upload-time = "2026-03-19T17:58:15.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/43/9570dbcda133c3da9248677f5ef102c0c79d88ede9dacfa5911e1b3cb963/toyplot-2.1.0-py3-none-any.whl", hash = "sha256:39c8c6e55add6b6f51acd1a5bcd964b3e6819137379fc3b8a9932ad365f641d5", size = 281485, upload-time = "2026-03-19T17:58:05.471Z" },
-]
-
-[[package]]
-name = "toytree"
-version = "3.0.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "loguru" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "pandas" },
-    { name = "requests" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "toyplot" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/bc/14dc4f31f376b3a1a6b9935a96f1e76dc5f4017ba9a1a71fa73ff1931c50/toytree-3.0.11.tar.gz", hash = "sha256:a117c56676889be72bdd6ce572a0bee26a299c5234d6fb6bf89dbc29bb960c12", size = 367166, upload-time = "2025-11-26T03:44:46.774Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/97/ae64477e109d790f61e7f73694659059ece5195ece835ff67defaed3964b/toytree-3.0.11-py3-none-any.whl", hash = "sha256:bc9857aedc54d7ed51bb0086330324815cfc8cb35c8c151cde720a6fc62410b3", size = 467620, upload-time = "2025-11-26T03:44:45.139Z" },
 ]
 
 [[package]]
@@ -7626,15 +7896,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
-]
-
-[[package]]
-name = "win32-setctime"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -253,21 +253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "alembic"
-version = "1.18.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mako" },
-    { name = "sqlalchemy" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
-]
-
-[[package]]
 name = "altair"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -790,15 +775,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,8 +1105,8 @@ name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and extra != 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
@@ -1425,20 +1401,6 @@ wheels = [
 ]
 
 [[package]]
-name = "databricks-sdk"
-version = "0.106.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "protobuf" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/b7/ef86e7b8c3d135c844f972e06efb628e147eed0a7b9a0ecbf9511437a3c2/databricks_sdk-0.106.0.tar.gz", hash = "sha256:6bbd492cb8593747aced037b9186f8632e9d553fc358e6f3d83b7e959851d9d3", size = 930953, upload-time = "2026-04-30T12:33:19.601Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/a9/63b4f6ef3078e4d060faaad85c4e43667189c3429edd68d5cbddc45187ca/databricks_sdk-0.106.0-py3-none-any.whl", hash = "sha256:db9de5566279ae80dfea0ecd37231e8968523ef984e83cbe4bd77e50c59aa6a5", size = 879452, upload-time = "2026-04-30T12:33:18.116Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1483,20 +1445,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1577,22 +1525,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastapi"
-version = "0.136.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
-]
-
-[[package]]
 name = "fastjsonschema"
 version = "2.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1608,36 +1540,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
-]
-
-[[package]]
-name = "flask"
-version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "blinker" },
-    { name = "click" },
-    { name = "itsdangerous" },
-    { name = "jinja2" },
-    { name = "markupsafe" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
-]
-
-[[package]]
-name = "flask-cors"
-version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flask" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
 ]
 
 [[package]]
@@ -1903,121 +1805,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-auth"
-version = "2.52.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/f8/80d2493cbedece1c623dc3e3cb1883300871af0dcdae254409522985ac23/google_auth-2.52.0.tar.gz", hash = "sha256:01f30e1a9e3638698d89464f5e603ce29d18e1c0e63ec31ac570aba4e164aaf5", size = 335027, upload-time = "2026-05-07T19:45:24.033Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/fc/2cdc74252746f547f81ff3f02d4d4234a3f411b5de5b61af97e633a060b9/google_auth-2.52.0-py3-none-any.whl", hash = "sha256:aee92803ba0ff93a70a3b8a35c7b4797837751cd6380b63ff38372b98f3ed627", size = 245614, upload-time = "2026-05-07T19:45:21.914Z" },
-]
-
-[[package]]
-name = "graphene"
-version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "graphql-core" },
-    { name = "graphql-relay" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/f6/bf62ff950c317ed03e77f3f6ddd7e34aaa98fe89d79ebd660c55343d8054/graphene-3.4.3.tar.gz", hash = "sha256:2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa", size = 44739, upload-time = "2024-11-09T20:44:25.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/e0/61d8e98007182e6b2aca7cf65904721fb2e4bce0192272ab9cb6f69d8812/graphene-3.4.3-py2.py3-none-any.whl", hash = "sha256:820db6289754c181007a150db1f7fff544b94142b556d12e3ebc777a7bf36c71", size = 114894, upload-time = "2024-11-09T20:44:23.851Z" },
-]
-
-[[package]]
-name = "graphql-core"
-version = "3.2.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
-]
-
-[[package]]
-name = "graphql-relay"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "graphql-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/13/98fbf8d67552f102488ffc16c6f559ce71ea15f6294728d33928ab5ff14d/graphql-relay-3.2.0.tar.gz", hash = "sha256:1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c", size = 50027, upload-time = "2022-04-16T11:03:45.447Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/16/a4cf06adbc711bd364a73ce043b0b08d8fa5aae3df11b6ee4248bcdad2e0/graphql_relay-3.2.0-py3-none-any.whl", hash = "sha256:c9b22bd28b170ba1fe674c74384a8ff30a76c8e26f88ac3aa1584dd3179953e5", size = 16940, upload-time = "2022-04-16T11:03:43.895Z" },
-]
-
-[[package]]
-name = "greenlet"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/03/84359833f7e1d49a883e92777637c592306030e30cee5e2b1e6476f95c88/greenlet-3.5.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a", size = 283502, upload-time = "2026-04-27T12:20:55.213Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ce/6f9f008266273aa14a2e011945797ac5802b97b8b40efe7afe1ee6c1afc9/greenlet-3.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f", size = 600508, upload-time = "2026-04-27T12:52:37.876Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/6d/b0f3272c2368ea2c1aa19a5ad70db0be8f8dff6e6d3d1eb82efa00cbcf19/greenlet-3.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb", size = 613283, upload-time = "2026-04-27T12:59:37.957Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/ae/1db979ff6ae7958d80b288f63d5f6c30df96682700ea9fc340ce994d94a1/greenlet-3.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd", size = 619894, upload-time = "2026-04-27T13:02:35.13Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb", size = 613418, upload-time = "2026-04-27T12:25:23.852Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/94/b0590e3d1978f02419f30502341c40d72f77eb0a2198119fe27df47714ee/greenlet-3.5.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243", size = 415681, upload-time = "2026-04-27T13:05:11.494Z" },
-    { url = "https://files.pythonhosted.org/packages/03/03/2b2b680ec87aaa97998fb5b8d76658d4d3560386864f17efab33ba7c2e24/greenlet-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977", size = 1572229, upload-time = "2026-04-27T12:53:23.509Z" },
-    { url = "https://files.pythonhosted.org/packages/61/e4/42b259e7a19aff1a270a4bd82caf6353109ed6860c9454e18f37162b83ae/greenlet-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0", size = 1639886, upload-time = "2026-04-27T12:25:22.325Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b4/733ca47b883b67c57f90d3ecb21055c9ec753597d10754ac201644061f9d/greenlet-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858", size = 237795, upload-time = "2026-04-27T12:21:40.118Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
-    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
-    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
-    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
-    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
-    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
-    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
-    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
-    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
-    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
-    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
-    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
-    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
-    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
-    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
-]
-
-[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2142,18 +1929,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gunicorn"
-version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2263,15 +2038,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "huey"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/29/3428d52eb8e85025e264a291641a9f9d6407cc1e51d1b630f6ac5815999a/huey-2.6.0.tar.gz", hash = "sha256:8d11f8688999d65266af1425b831f6e3773e99415027177b8734b0ffd5e251f6", size = 221068, upload-time = "2026-01-06T03:01:02.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/34/fae9ac8f1c3a552fd3f7ff652b94c78d219dedc5fce0c0a4232457760a00/huey-2.6.0-py3-none-any.whl", hash = "sha256:1b9df9d370b49c6d5721ba8a01ac9a787cf86b3bdc584e4679de27b920395c3f", size = 76951, upload-time = "2026-01-06T03:01:00.808Z" },
 ]
 
 [[package]]
@@ -2427,7 +2193,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2593,15 +2359,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -3051,18 +2808,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mako"
-version = "1.3.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3389,90 +3134,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/fb/8091c0aee7f2712de99c7fd4b1642382644dec6a4962effe4f5b9d16a973/ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b76fa1d3f92967d58289ac47ab7458ede66e6f3527fff3e59142aee57d9307cd", size = 430645, upload-time = "2026-08-13T14:14:23.737Z" },
     { url = "https://files.pythonhosted.org/packages/c4/6f/962d2c589513b5930d05b6eae5fbd22ad8bbcf26bb763449f3d8f912360f/ml_dtypes-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3be9911d953f97cddded4b9961d7b650473b7e55806d20f6176f8356dfe7b38e", size = 465667, upload-time = "2026-08-13T14:14:25.04Z" },
     { url = "https://files.pythonhosted.org/packages/aa/ca/bcb25e246edd19af5fa1cf6267040bd9977a7afca846e6cfd4a52078b44f/ml_dtypes-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e74266ca8e97874a937b7646378c178025650a236584f7474d10d8086a6edea3", size = 572706, upload-time = "2026-08-13T14:14:26.296Z" },
-]
-
-[[package]]
-name = "mlflow"
-version = "3.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "alembic" },
-    { name = "cryptography" },
-    { name = "docker" },
-    { name = "flask" },
-    { name = "flask-cors" },
-    { name = "graphene" },
-    { name = "gunicorn", marker = "sys_platform != 'win32' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "huey" },
-    { name = "matplotlib" },
-    { name = "mlflow-skinny" },
-    { name = "mlflow-tracing" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "skops" },
-    { name = "sqlalchemy" },
-    { name = "waitress", marker = "sys_platform == 'win32' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/e3/b2148a6d6f38731d3dda49a7e46cf6932a458aa0aa5414b80e6e7251fa1d/mlflow-3.12.0.tar.gz", hash = "sha256:227ee31c6abf7ae3b3c38d4ca87c356e107578740c1efee89da43f2a5b9e3b47", size = 9939137, upload-time = "2026-05-05T10:28:58.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f8/47f28975c1c1b70d351fa19c5aef21cef5ae1e1aca36bd1858798384bdbb/mlflow-3.12.0-py3-none-any.whl", hash = "sha256:e1c28ed4c48557cc52c766f17f1ca5826753ddf241d43f30f99c45f7ea6b3ce0", size = 10625639, upload-time = "2026-05-05T10:28:55.777Z" },
-]
-
-[[package]]
-name = "mlflow-skinny"
-version = "3.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "click" },
-    { name = "cloudpickle" },
-    { name = "databricks-sdk" },
-    { name = "fastapi" },
-    { name = "gitpython" },
-    { name = "importlib-metadata" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sqlparse" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "uvicorn" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/c0/9cbe24b4abcbadb3a3cdab65bfd552b6b75de64374b477abac89190d25d0/mlflow_skinny-3.12.0.tar.gz", hash = "sha256:74d27066bc9553d281e0c31d25f07deb39dbe99d190e4f7c257703e5c8ee6d10", size = 2723866, upload-time = "2026-05-05T10:28:46.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/05/2df60fab37881c490e9364ea697a6c3a78d3b593fde2d9332a75f8cdf1f8/mlflow_skinny-3.12.0-py3-none-any.whl", hash = "sha256:0498f3697abcabcc6204c432ef179840f6a7a34ce123837c98c1913064fda6dd", size = 3261903, upload-time = "2026-05-05T10:28:44.24Z" },
-]
-
-[[package]]
-name = "mlflow-tracing"
-version = "3.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "databricks-sdk" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/13/d32fe4cca53dde68f09fd38c545ea709e8565fd7c2ffd7c5eff99e504aaf/mlflow_tracing-3.12.0.tar.gz", hash = "sha256:8702a34a1d4f1517ba904d716f5a8fca4675e6526f7d164d02bdaabececa2d80", size = 1352412, upload-time = "2026-05-05T10:28:51.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/bf/e22b778addbe19a7a912400c37a197ee9cdebc1641e3b0a3882c30da6ee4/mlflow_tracing-3.12.0-py3-none-any.whl", hash = "sha256:c6072553f47b42505dc7ee62946688a4a0dde8f06b78fbc60e946397b20e1518", size = 1618720, upload-time = "2026-05-05T10:28:48.999Z" },
 ]
 
 [[package]]
@@ -4865,58 +4526,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-api"
-version = "1.41.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.41.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.41.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
-]
-
-[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5146,18 +4755,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
-]
-
-[[package]]
-name = "prettytable"
-version = "3.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -5411,27 +5008,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -5706,15 +5282,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -6285,129 +5852,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-learn"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version < '3.11' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-]
-dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
-    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
-    { url = "https://files.pythonhosted.org/packages/43/83/564e141eef908a5863a54da8ca342a137f45a0bfb71d1d79704c9894c9d1/scikit_learn-1.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7509693451651cd7361d30ce4e86a1347493554f172b1c72a39300fa2aea79e", size = 9331967, upload-time = "2025-09-09T08:20:32.421Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d6/ba863a4171ac9d7314c4d3fc251f015704a2caeee41ced89f321c049ed83/scikit_learn-1.7.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0486c8f827c2e7b64837c731c8feff72c0bd2b998067a8a9cbc10643c31f0fe1", size = 8648645, upload-time = "2025-09-09T08:20:34.436Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89877e19a80c7b11a2891a27c21c4894fb18e2c2e077815bcade10d34287b20d", size = 9715424, upload-time = "2025-09-09T08:20:36.776Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/32/1f3b22e3207e1d2c883a7e09abb956362e7d1bd2f14458c7de258a26ac15/scikit_learn-1.7.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8da8bf89d4d79aaec192d2bda62f9b56ae4e5b4ef93b6a56b5de4977e375c1f1", size = 9509234, upload-time = "2025-09-09T08:20:38.957Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/71/34ddbd21f1da67c7a768146968b4d0220ee6831e4bcbad3e03dd3eae88b6/scikit_learn-1.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9b7ed8d58725030568523e937c43e56bc01cadb478fc43c042a9aca1dacb3ba1", size = 8894244, upload-time = "2025-09-09T08:20:41.166Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/aa/3996e2196075689afb9fce0410ebdb4a09099d7964d061d7213700204409/scikit_learn-1.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d91a97fa2b706943822398ab943cde71858a50245e31bc71dba62aab1d60a96", size = 9259818, upload-time = "2025-09-09T08:20:43.19Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5d/779320063e88af9c4a7c2cf463ff11c21ac9c8bd730c4a294b0000b666c9/scikit_learn-1.7.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:acbc0f5fd2edd3432a22c69bed78e837c70cf896cd7993d71d51ba6708507476", size = 8636997, upload-time = "2025-09-09T08:20:45.468Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5bf3d930aee75a65478df91ac1225ff89cd28e9ac7bd1196853a9229b6adb0b", size = 9478381, upload-time = "2025-09-09T08:20:47.982Z" },
-    { url = "https://files.pythonhosted.org/packages/82/70/8bf44b933837ba8494ca0fc9a9ab60f1c13b062ad0197f60a56e2fc4c43e/scikit_learn-1.7.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4d6e9deed1a47aca9fe2f267ab8e8fe82ee20b4526b2c0cd9e135cea10feb44", size = 9300296, upload-time = "2025-09-09T08:20:50.366Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/99/ed35197a158f1fdc2fe7c3680e9c70d0128f662e1fee4ed495f4b5e13db0/scikit_learn-1.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:6088aa475f0785e01bcf8529f55280a3d7d298679f50c0bb70a2364a82d0b290", size = 8731256, upload-time = "2025-09-09T08:20:52.627Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
-    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
-    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
-    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
-    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
-    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
-    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
-    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
-]
-
-[[package]]
-name = "scikit-learn"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version >= '3.14' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.13.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.12.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-    "python_full_version == '3.11.*' and extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128'",
-]
-dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
-    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
-    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
-    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
-    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
-    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
-    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
-    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
-    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
-    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
-    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
-]
-
-[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6586,19 +6030,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sentry-sdk"
-version = "2.59.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/65/e0/9bf5e5fc7442b10880f3ec0eff0ef4208b84a099606f343ec4f5445227fb/sentry_sdk-2.59.0.tar.gz", hash = "sha256:cd265808ef8bf3f3edf69b527c0a0b2b6b1322762679e55b8987db2e9584aec1", size = 447331, upload-time = "2026-05-04T12:19:06.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/00/b8cc413748fb6383d1582e7cda51314f99743351c462a92dc690d5b5853b/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe", size = 468432, upload-time = "2026-05-04T12:19:04.741Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6623,25 +6054,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "skops"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "packaging" },
-    { name = "prettytable" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", size = 608084, upload-time = "2026-04-20T18:23:55.336Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/0e/3ae19fa941522cd98e119762e7181d371c8dba0b2d72bfaf9522692e329c/skops-0.14.0-py3-none-any.whl", hash = "sha256:60a5db78a9db46ccee2139a0ba13ab5afb1c96f4749b382e75a371291bbe3e36", size = 132198, upload-time = "2026-04-20T18:23:54.018Z" },
 ]
 
 [[package]]
@@ -6841,75 +6253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlalchemy"
-version = "2.0.49"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/76/f908955139842c362aa877848f42f9249642d5b69e06cee9eae5111da1bd/sqlalchemy-2.0.49-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f", size = 2159321, upload-time = "2026-04-03T16:50:11.8Z" },
-    { url = "https://files.pythonhosted.org/packages/24/e2/17ba0b7bfbd8de67196889b6d951de269e8a46057d92baca162889beb16d/sqlalchemy-2.0.49-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b", size = 3238937, upload-time = "2026-04-03T16:54:45.731Z" },
-    { url = "https://files.pythonhosted.org/packages/90/1e/410dd499c039deacff395eec01a9da057125fcd0c97e3badc252c6a2d6a7/sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1", size = 3237188, upload-time = "2026-04-03T16:56:53.217Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/06/e797a8b98a3993ac4bc785309b9b6d005457fc70238ee6cefa7c8867a92e/sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:62557958002b69699bdb7f5137c6714ca1133f045f97b3903964f47db97ea339", size = 3190061, upload-time = "2026-04-03T16:54:47.489Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d3/5a9f7ef580af1031184b38235da6ac58c3b571df01c9ec061c44b2b0c5a6/sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:da9b91bca419dc9b9267ffadde24eae9b1a6bffcd09d0a207e5e3af99a03ce0d", size = 3211477, upload-time = "2026-04-03T16:56:55.056Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ec/7be8c8cb35f038e963a203e4fe5a028989167cc7299927b7cf297c271e37/sqlalchemy-2.0.49-cp310-cp310-win32.whl", hash = "sha256:5e61abbec255be7b122aa461021daa7c3f310f3e743411a67079f9b3cc91ece3", size = 2119965, upload-time = "2026-04-03T17:00:50.009Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/31/0defb93e3a10b0cf7d1271aedd87251a08c3a597ee4f353281769b547b5a/sqlalchemy-2.0.49-cp310-cp310-win_amd64.whl", hash = "sha256:0c98c59075b890df8abfcc6ad632879540f5791c68baebacb4f833713b510e75", size = 2142935, upload-time = "2026-04-03T17:00:51.675Z" },
-    { url = "https://files.pythonhosted.org/packages/60/b5/e3617cc67420f8f403efebd7b043128f94775e57e5b84e7255203390ceae/sqlalchemy-2.0.49-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe", size = 2159126, upload-time = "2026-04-03T16:50:13.242Z" },
-    { url = "https://files.pythonhosted.org/packages/20/9b/91ca80403b17cd389622a642699e5f6564096b698e7cdcbcbb6409898bc4/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014", size = 3315509, upload-time = "2026-04-03T16:54:49.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/61/0722511d98c54de95acb327824cb759e8653789af2b1944ab1cc69d32565/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536", size = 3315014, upload-time = "2026-04-03T16:56:56.376Z" },
-    { url = "https://files.pythonhosted.org/packages/46/55/d514a653ffeb4cebf4b54c47bec32ee28ad89d39fafba16eeed1d81dccd5/sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88", size = 3267388, upload-time = "2026-04-03T16:54:51.272Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/16/0dcc56cb6d3335c1671a2258f5d2cb8267c9a2260e27fde53cbfb1b3540a/sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700", size = 3289602, upload-time = "2026-04-03T16:56:57.63Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6c/f8ab6fb04470a133cd80608db40aa292e6bae5f162c3a3d4ab19544a67af/sqlalchemy-2.0.49-cp311-cp311-win32.whl", hash = "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a", size = 2119044, upload-time = "2026-04-03T17:00:53.455Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/59/55a6d627d04b6ebb290693681d7683c7da001eddf90b60cfcc41ee907978/sqlalchemy-2.0.49-cp311-cp311-win_amd64.whl", hash = "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af", size = 2143642, upload-time = "2026-04-03T17:00:54.769Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
-    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
-    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
-    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
-    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
-    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
-    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
-    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
-    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
-    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
-]
-
-[[package]]
-name = "sqlparse"
-version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
-]
-
-[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7017,6 +6360,30 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "adabelief-pytorch" },
+    { name = "chytorch-rxnmap-synplan" },
+    { name = "chytorch-synplan" },
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "matplotlib" },
+    { name = "matplotlib-venn" },
+    { name = "onnx" },
+    { name = "onnxscript" },
+    { name = "pandas" },
+    { name = "pytorch-lightning" },
+    { name = "safetensors" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "streamlit" },
+    { name = "streamlit-ketcher" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch-geometric" },
+]
 cpu = [
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -7030,51 +6397,32 @@ cu128 = [
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
     { name = "torch-geometric" },
 ]
+curation = [
+    { name = "chytorch-rxnmap-synplan" },
+    { name = "chytorch-synplan" },
+    { name = "pandas" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
+]
 gui = [
     { name = "pandas" },
     { name = "streamlit" },
     { name = "streamlit-ketcher" },
 ]
-loggers = [
-    { name = "mlflow" },
-    { name = "wandb" },
-]
-mapping = [
-    { name = "chytorch-rxnmap-synplan" },
-    { name = "chytorch-synplan" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-]
-mlflow = [
-    { name = "mlflow" },
-]
-notebooks = [
+training = [
+    { name = "adabelief-pytorch" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
-    { name = "pandas" },
-]
-onnx-export = [
     { name = "onnx" },
     { name = "onnxscript" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch-geometric" },
-]
-torch = [
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra != 'extra-10-synplanner-cu126' and extra != 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
-    { name = "torch-geometric" },
-]
-training = [
-    { name = "adabelief-pytorch" },
+    { name = "pandas" },
     { name = "pytorch-lightning" },
     { name = "safetensors" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -7083,9 +6431,6 @@ training = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-10-synplanner-cu126' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch-geometric" },
-]
-wandb = [
-    { name = "wandb" },
 ]
 
 [package.dev-dependencies]
@@ -7096,7 +6441,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "synplanner", extra = ["mapping", "notebooks", "onnx-export", "training"] },
+    { name = "synplanner", extra = ["curation", "training"] },
     { name = "twine" },
 ]
 docs = [
@@ -7113,49 +6458,45 @@ docs = [
 requires-dist = [
     { name = "adabelief-pytorch", marker = "extra == 'training'", specifier = ">=0.2.1" },
     { name = "chython-synplan", extras = ["racer-default"], specifier = "==1.108" },
-    { name = "chytorch-rxnmap-synplan", marker = "extra == 'mapping'", specifier = ">=1.7" },
-    { name = "chytorch-synplan", marker = "extra == 'mapping'", specifier = ">=1.70" },
+    { name = "chytorch-rxnmap-synplan", marker = "extra == 'curation'", specifier = ">=1.7" },
+    { name = "chytorch-synplan", marker = "extra == 'curation'", specifier = ">=1.70" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "frozendict", specifier = ">=2.4.6" },
     { name = "huggingface-hub", specifier = ">=0.24.0" },
     { name = "ijson", specifier = ">=3.4.0" },
-    { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">6.29.0" },
-    { name = "ipywidgets", marker = "extra == 'notebooks'", specifier = ">8.1.0" },
-    { name = "matplotlib", marker = "extra == 'notebooks'", specifier = ">=3.7" },
-    { name = "matplotlib-venn", marker = "extra == 'notebooks'", specifier = ">=1.1" },
-    { name = "mlflow", marker = "extra == 'loggers'", specifier = ">=2" },
-    { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=2" },
+    { name = "ipykernel", marker = "extra == 'training'", specifier = ">6.29.0" },
+    { name = "ipywidgets", marker = "extra == 'training'", specifier = ">8.1.0" },
+    { name = "matplotlib", marker = "extra == 'training'", specifier = ">=3.7" },
+    { name = "matplotlib-venn", marker = "extra == 'training'", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=2" },
-    { name = "onnx", marker = "extra == 'onnx-export'", specifier = ">=1.17" },
+    { name = "onnx", marker = "extra == 'training'", specifier = ">=1.17" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = ">=1.23,<1.24" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.23" },
-    { name = "onnxscript", marker = "extra == 'onnx-export'", specifier = ">=0.5" },
+    { name = "onnxscript", marker = "extra == 'training'", specifier = ">=0.5" },
+    { name = "pandas", marker = "extra == 'curation'", specifier = ">=1.4" },
     { name = "pandas", marker = "extra == 'gui'", specifier = ">=1.4" },
-    { name = "pandas", marker = "extra == 'notebooks'", specifier = ">=1.4" },
+    { name = "pandas", marker = "extra == 'training'", specifier = ">=1.4" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytorch-lightning", marker = "extra == 'training'", specifier = ">=2.3.3,!=2.6.2,!=2.6.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rdkit", specifier = ">=2023.9.1" },
     { name = "safetensors", marker = "extra == 'training'", specifier = ">=0.4" },
-    { name = "scipy", marker = "extra == 'mapping'", specifier = ">=1.10" },
+    { name = "scipy", marker = "extra == 'curation'", specifier = ">=1.10" },
     { name = "streamlit", marker = "extra == 'gui'", specifier = ">1.35.1" },
     { name = "streamlit-ketcher", marker = "extra == 'gui'", specifier = ">=0.0.1" },
-    { name = "synplanner", extras = ["torch"], marker = "extra == 'cpu'" },
-    { name = "synplanner", extras = ["torch"], marker = "extra == 'cu126'" },
-    { name = "synplanner", extras = ["torch"], marker = "extra == 'cu128'" },
-    { name = "synplanner", extras = ["torch"], marker = "extra == 'onnx-export'" },
-    { name = "synplanner", extras = ["torch"], marker = "extra == 'training'" },
+    { name = "synplanner", extras = ["curation", "training", "gui"], marker = "extra == 'all'" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "synplanner", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cu126'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "synplanner", extra = "cu126" } },
     { name = "torch", marker = "extra == 'cu128'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "synplanner", extra = "cu128" } },
-    { name = "torch", marker = "extra == 'onnx-export'", specifier = ">=2.6" },
-    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0" },
-    { name = "torch-geometric", marker = "extra == 'torch'", specifier = ">=2.4.0" },
+    { name = "torch", marker = "extra == 'curation'", specifier = ">=2.0" },
+    { name = "torch", marker = "extra == 'training'", specifier = ">=2.6" },
+    { name = "torch-geometric", marker = "extra == 'cpu'", specifier = ">=2.4.0" },
+    { name = "torch-geometric", marker = "extra == 'cu126'", specifier = ">=2.4.0" },
+    { name = "torch-geometric", marker = "extra == 'cu128'", specifier = ">=2.4.0" },
+    { name = "torch-geometric", marker = "extra == 'training'", specifier = ">=2.4.0" },
     { name = "tqdm", specifier = ">=4.66" },
-    { name = "wandb", marker = "extra == 'loggers'", specifier = ">=0.17" },
-    { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.17" },
 ]
-provides-extras = ["torch", "training", "mapping", "notebooks", "gui", "onnx-export", "cpu", "cu126", "cu128", "wandb", "mlflow", "loggers"]
+provides-extras = ["curation", "training", "gui", "all", "cpu", "cu126", "cu128"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -7165,7 +6506,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.14.4,<0.15" },
-    { name = "synplanner", extras = ["training", "mapping", "notebooks", "onnx-export"] },
+    { name = "synplanner", extras = ["curation", "training"] },
     { name = "twine", specifier = ">=6.2.0,<7" },
 ]
 docs = [
@@ -7207,15 +6548,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
-]
-
-[[package]]
-name = "threadpoolctl"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -7737,44 +7069,6 @@ wheels = [
 ]
 
 [[package]]
-name = "waitress"
-version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
-]
-
-[[package]]
-name = "wandb"
-version = "0.26.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "gitpython" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sentry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/a4/72a6640e1f566e81f184a426e3e45298d4c6672664de41adb7eb6f64370a/wandb-0.26.1.tar.gz", hash = "sha256:eef2dbaea06f0b1c0cdc5d76f544ae4c2b8848fc512442a00bd59f0502fc8aa1", size = 42159814, upload-time = "2026-04-23T16:27:34.033Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/09/3296235f3906e904f06f2df29eed4d672fb23c0932c9486e2af64f2f2a66/wandb-0.26.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2955fe190c005fb83ee6d73f066c8a33f09f3212a1f2eb53faa6581440e456be", size = 24857204, upload-time = "2026-04-23T16:26:58.576Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/ad/e39ca3086534129e42208ba00ed2c6247ce425f890219eeec33b4f162864/wandb-0.26.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:55d91cabde98162d7116a5e19ddd052bd9848556243f1da4cbb9ffb7ad435bfc", size = 26014649, upload-time = "2026-04-23T16:27:02.559Z" },
-    { url = "https://files.pythonhosted.org/packages/56/af/400d84a3bdce0b062b4baa70acb6becd2c8018697f4fbf5af9a9e1e406e5/wandb-0.26.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7c78bc2454cfe1ffa1c3a256060a387356eed8a4488e024d9d2eba8f2b5bd51d", size = 25421317, upload-time = "2026-04-23T16:27:06.411Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/b4bf8f3509dcea1cec52233a38991459654635b5a8e6a494eb912e1b9cfb/wandb-0.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a2c8eeec8706dcd2872e69c3b4d20ec523082fdb4440295491556e219ad2aa67", size = 27192831, upload-time = "2026-04-23T16:27:10.308Z" },
-    { url = "https://files.pythonhosted.org/packages/62/cf/4a6dce0c782223ef0eeea7139daee73418a7322befcf083512c31cebaa18/wandb-0.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2fa768ee0636a569afb7541cf996e56309c47070566a38916823f94e02afe586", size = 25593326, upload-time = "2026-04-23T16:27:14.259Z" },
-    { url = "https://files.pythonhosted.org/packages/df/99/58c3d8c36ae8e2b7d70bf6493eb5daa1cca0231a04b025717b4cd1a78f1e/wandb-0.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5854928725cfeff1f284d5c043cd353f810e5da02eead2c120ef5056ad026fea", size = 27535542, upload-time = "2026-04-23T16:27:18.473Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d0/4e846ffc1d0cc435518dfa581ce73ac82cfd0ebbf35f3853c9277f632e5f/wandb-0.26.1-py3-none-win32.whl", hash = "sha256:5c2bd44e575ae9944e2764d1aaa031461178276bf2636d5558399c2816ef5cfe", size = 24968151, upload-time = "2026-04-23T16:27:22.086Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9b/487413eaccefdb58799a226726e24b486e9192d2671c75a4550c160aba23/wandb-0.26.1-py3-none-win_amd64.whl", hash = "sha256:5817785467d3f1676f1812ec19a89f77f6e56dfe67d9f47080075af95f705d3e", size = 24968155, upload-time = "2026-04-23T16:27:25.731Z" },
-    { url = "https://files.pythonhosted.org/packages/04/dc/5baf3e99b3eeb709d6f75124b5bec8cb73d4b38d2b10df7fdcfde4966200/wandb-0.26.1-py3-none-win_arm64.whl", hash = "sha256:f848b7744f896bc04cabbb28360a2814d1551a91fa2c456243e06435729c8a2e", size = 22912416, upload-time = "2026-04-23T16:27:29.456Z" },
-]
-
-[[package]]
 name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7908,18 +7202,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "werkzeug"
-version = "3.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -6353,6 +6353,7 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rdkit" },
@@ -6370,7 +6371,6 @@ all = [
     { name = "matplotlib-venn" },
     { name = "onnx" },
     { name = "onnxscript" },
-    { name = "pandas" },
     { name = "pytorch-lightning" },
     { name = "safetensors" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -6400,7 +6400,6 @@ cu128 = [
 curation = [
     { name = "chytorch-rxnmap-synplan" },
     { name = "chytorch-synplan" },
-    { name = "pandas" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -6410,7 +6409,6 @@ curation = [
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra != 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128') or (extra != 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128')" },
 ]
 gui = [
-    { name = "pandas" },
     { name = "streamlit" },
     { name = "streamlit-ketcher" },
 ]
@@ -6422,7 +6420,6 @@ training = [
     { name = "matplotlib-venn" },
     { name = "onnx" },
     { name = "onnxscript" },
-    { name = "pandas" },
     { name = "pytorch-lightning" },
     { name = "safetensors" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-synplanner-cpu') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu126') or (extra == 'extra-10-synplanner-cpu' and extra == 'extra-10-synplanner-cu128') or (extra == 'extra-10-synplanner-cu126' and extra == 'extra-10-synplanner-cu128')" },
@@ -6473,9 +6470,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = ">=1.23,<1.24" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.23" },
     { name = "onnxscript", marker = "extra == 'training'", specifier = ">=0.5" },
-    { name = "pandas", marker = "extra == 'curation'", specifier = ">=1.4" },
-    { name = "pandas", marker = "extra == 'gui'", specifier = ">=1.4" },
-    { name = "pandas", marker = "extra == 'training'", specifier = ">=1.4" },
+    { name = "pandas", specifier = ">=1.4" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytorch-lightning", marker = "extra == 'training'", specifier = ">=2.3.3,!=2.6.2,!=2.6.3" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces CPU-only ONNX policy and value-network inference, adds checkpoint export and preset preference for ONNX artifacts, and reorganizes dependencies into workflow-specific extras.

- Adds shared NumPy/PyG molecular featurization and ONNX-backed policy/value evaluation.
- Lazily imports optional training, mapping, notebook, and Torch functionality so the base CLI can run without Torch.
- Updates installation guidance, preset downloads, tests, and dependency locking for the new workflow extras.
- Leaves the advertised training notebook environment incomplete because its extra omits the notebook dependencies removed from the base package.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the training extra or its documentation is corrected so the advertised notebook workflow is actually installed.

The ONNX and lazy-import paths are internally consistent, but the dependency reorganization removes the notebook packages while repeatedly promising that the training extra includes them.

**Files Needing Attention:** pyproject.toml, README.md, docs/configuration/policy.rst, skills/synplanner-usage/SKILL.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Splits the former all-in-one dependency set into base, curation, training, GUI, and Torch-backend extras, but the training extra does not fulfill the newly documented notebook-tool contract. |
| scripts/export_policy_onnx.py | Adds export of supported linear policy and value checkpoints with dynamic graph dimensions and model metadata. |
| synplan/mcts/policy/onnx.py | Adds CPU ONNX Runtime inference while preserving ranking/filtering selection and rule-vocabulary validation interfaces. |
| synplan/ml/featurization/molecules.py | Centralizes graph feature construction in NumPy and wraps the same arrays for PyG to keep Torch and ONNX inputs aligned. |
| synplan/utils/loading.py | Dispatches ONNX models to the new runtime and prefers same-name ONNX preset artifacts while retaining guarded checkpoint loading. |
| synplan/mcts/evaluation.py | Adds metadata-validated ONNX value-network evaluation without requiring Torch on that path. |
| synplan/interfaces/cli.py | Moves mapping and training imports into their command handlers so base CLI startup avoids optional heavy dependencies. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Checkpoint] --> E[ONNX exporter]
  E --> O[ONNX model with SynPlanner metadata]
  P[Preset downloader] -->|prefer matching .onnx| O
  O --> L[Policy/value loader]
  M[Molecule] --> F[NumPy featurization]
  F --> L
  L --> R[ONNX Runtime CPU inference]
  R --> S[MCTS planning]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #112 from Laboratoire..."](https://github.com/laboratoire-de-chemoinformatique/synplanner/commit/85f527d4df3eb7be1a3c2ac9fd5828aa62391998) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62571097)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->